### PR TITLE
사이드바 스크롤시 그림자 생성 & 버그 몇가지 수정

### DIFF
--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -5,7 +5,7 @@ import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 import BookmarkAddButton from "../presentationals/BookmarkAddButton";
 
-export default function BookmarkContainer() {
+export default function BookmarkContainer({ onScroll }) {
 	const bookmarkItems = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }];
 
 	const handleCustomButtonClick = () => {
@@ -13,7 +13,7 @@ export default function BookmarkContainer() {
 	};
 
 	return (
-		<ListLayout>
+		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"북마크 수식 목록"} />
 			{bookmarkItems.map(({ id, latex }) =>
 				<ListItem

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -4,7 +4,7 @@ import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 
-export default function RecentContainer() {
+export default function RecentContainer({ onScroll }) {
 	const recentItems = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }, { id: 3, latex: "6 + 7" }, { id: 4, latex: "6 + 7" }];
 
 	const handleBookmarkButtonClick = () => {
@@ -16,7 +16,7 @@ export default function RecentContainer() {
 	};
 
 	return (
-		<ListLayout>
+		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"최근 수식 목록"} />
 			{recentItems.map(({ id, latex }) =>
 				<ListItem

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -5,7 +5,7 @@ import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 
 export default function RecentContainer() {
-	const recentItems = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }];
+	const recentItems = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }, { id: 3, latex: "6 + 7" }, { id: 4, latex: "6 + 7" }];
 
 	const handleBookmarkButtonClick = () => {
 		console.log("bookmark");

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -9,10 +9,15 @@ import CustomContainer from "./CustomContainer";
 export default function SideBar() {
 	const [tabState, setTabState] = useState(0);
 	const [isOpenSidebar, setIsOpenSidebar] = useState("hide");
+	const [isScrollTop, setIsScrollTop] = useState(true);
+
+	const handleSidebarScroll = ({ target }) => {
+		setIsScrollTop(!target.scrollTop);
+	};
 
 	const tabMap = {
-		0: <RecentContainer />,
-		1: <BookmarkContainer />,
+		0: <RecentContainer onScroll={handleSidebarScroll}/>,
+		1: <BookmarkContainer onScroll={handleSidebarScroll}/>,
 		2: <CustomContainer />,
 	};
 
@@ -28,7 +33,7 @@ export default function SideBar() {
 		<SideBarLayout className={isOpenSidebar}>
 			<button onClick={handleToggleSidebar}>{isOpenSidebar === "hide" ? "<" : ">"}</button>
 			<div>
-				<SideBarTab currentTab={tabState} onClick={handleTabClick} />
+				<SideBarTab currentTab={tabState} onClick={handleTabClick} isScrollTop={isScrollTop}/>
 				{tabMap[tabState]}
 			</div>
 		</SideBarLayout>

--- a/src/layouts/ListLayout.js
+++ b/src/layouts/ListLayout.js
@@ -1,5 +1,8 @@
 import styled from "styled-components";
 
-const ListLayout = styled.div``;
+const ListLayout = styled.div`
+  overflow: auto;
+  height: 100%;
+`;
 
 export default ListLayout;

--- a/src/layouts/ListLayout.js
+++ b/src/layouts/ListLayout.js
@@ -1,8 +1,9 @@
 import styled from "styled-components";
 
 const ListLayout = styled.div`
-  overflow: auto;
+  overflow: overlay;
   height: 100%;
+  padding: 10px 10px 60px 10px;
 `;
 
 export default ListLayout;

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -2,7 +2,14 @@ import styled from "styled-components";
 
 const MainLayout = styled.div`
   margin: 0 auto;
-  width: 1000px;
+  width: 100%;
+
+  @media(max-width: 500px) {
+    width: 500px;
+  }
+  @media(min-width: 1000px) {
+    width: 1000px;
+  }
 `;
 
 export default MainLayout;

--- a/src/layouts/SideBarLayout.js
+++ b/src/layouts/SideBarLayout.js
@@ -12,11 +12,11 @@ const SideBarLayout = styled.div`
 	top: 0;
 	right: 0;
 	transition: 1s;
+	z-index: 5;
 
 	> div {
 		width: 100%;
 		border: 1px solid black;
-		z-index: 5;
 		background-color: white;
 	}
 	> button {

--- a/src/presentationals/FormulaRepresentation.jsx
+++ b/src/presentationals/FormulaRepresentation.jsx
@@ -4,7 +4,7 @@ import { addStyles, EditableMathField } from "react-mathquill";
 
 addStyles();
 
-const FormulaRepresentationStyle = styled.div.attrs(({ fontInfo: { color } }) => ({ color }))`
+const FormulaRepresentationStyle = styled.div.attrs(({ fontInfo: { color } }) => ({ style: { color } }))`
   height: 300px;
   border: 1px solid black;
 	display: flex;

--- a/src/presentationals/SideBarTab.jsx
+++ b/src/presentationals/SideBarTab.jsx
@@ -11,6 +11,9 @@ const TabLayout = styled.div`
 	display: flex;
 	justify-content: space-around;
 	padding-top: 10px;
+	z-index: 1000;
+	position: relative;
+	${({ isScrollTop }) => (!isScrollTop && "box-shadow: 0 12px 15px -15px grey;")}
 `;
 
 const Tab = styled.div`
@@ -27,11 +30,11 @@ const Tab = styled.div`
 	)}
 `;
 
-export default function SideBarTab({ currentTab, onClick }) {
+export default function SideBarTab({ currentTab, onClick, isScrollTop }) {
 	const tabMenus = [<TimeIcon key="0"/>, <EmptyStarIcon key="1"/>, <CustomIcon key="2"/>];
 
 	return (
-		<TabLayout>
+		<TabLayout isScrollTop={isScrollTop}>
 			{tabMenus.map((tabMenu, index) =>
 				<Tab onClick={onClick(index)} key={index} isSelected={currentTab === index}>
 					<IconButton isHover={currentTab !== index} icon={tabMenu} />

--- a/src/slice.js
+++ b/src/slice.js
@@ -7,7 +7,7 @@ const { reducer, actions } = createSlice({
 		latexInput: "",
 		fontInfo: {
 			size: "15",
-			color: "black",
+			color: "#000000",
 		},
 		alignInfo: "center",
 	},


### PR DESCRIPTION
## 변경사항
- 메인 페이지의 width가 500 ~ 1000px 까지 창 크기에 맞춰 변경
- 사이드바 오픈 버튼이 수식 편집기 `z-index`에 가려 안눌리는 버그 수정
- 사이드바의 아이템이 넘치면 아래를 볼 수 없었던 버그 수정
- 수식 편집기의 폰트색상이 변경되지 않는 버그 수정
- 수식 편집기의 초기 컬러가 `black`이 들어가면 경고가 떠서 `#000000`으로 수정

## 추가사항
- 사이드바 리스트 레이아웃에 스크롤 이벤트를 읽어서 scrollTop이 0이 아니면 그림자가 생김

|그림자 생성|
|:-:|
|![](https://i.imgur.com/ak26qlR.png)|