### PR TITLE
메인 페이지 overflow 수정 및 사이드바 position 수정

### DIFF
--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -8,7 +8,7 @@ const GlobalStyle = createGlobalStyle`
 	}
 
 	body {
-		overflow: hidden;
+		overflow-x: hidden;
 	}
 `;
 

--- a/src/layouts/SideBarLayout.js
+++ b/src/layouts/SideBarLayout.js
@@ -10,7 +10,7 @@ const SideBarLayout = styled.div`
 	flex-direction: row;
 	width: ${layoutWidth}px;
 	height: 100%;
-	position: absolute;
+	position: fixed;
 	top: 0;
 	right: 0;
 	transition: 1s;


### PR DESCRIPTION
## 변경사항

- 메인 페이지 `overflow: hidden` 때문에 창이 작으면 y축 스크롤이 없어 내릴 수 없는 문제
  - `overflow-x: hidden`으로 변경해서 y축 스크롤은 생기게 변경
  - 하지만 내리면 사이드바가 `position: absoulte`라서 하단에 이상하게 나오는 문제 발생
- 사이드바를 `position: fixed`로 수정해서 항상 따라다니게 변경

**[클릭해서 확대해서 보세요]**

|변경 전 | 1단 변신|2단 변신|
|:-:|:-:|:-:|
|![](https://i.imgur.com/l4PTSfe.png)|![](https://i.imgur.com/0VGICOd.png)|![gif](https://user-images.githubusercontent.com/43347250/100408262-e090e600-30ad-11eb-9c07-dfa4abbc9d63.gif)|