### PR TITLE
최근 수식 기능 구현 및 북마크와 상태 공유 리팩토링

### DIFF
--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -11,7 +11,7 @@ import EmptyItem from "../presentationals/EmptyItem";
 
 export default function BookmarkContainer({ onScroll, setSidebar, setTabState }) {
 	const dispatch = useDispatch();
-	const { bookmarkItems } = useSelector(state => state);
+	const { bookmarkItems, latexInput } = useSelector(state => state);
 
 	const handleCustomButtonClick = latex => () => {
 		dispatch(setCustomCommand(latex));
@@ -24,7 +24,7 @@ export default function BookmarkContainer({ onScroll, setSidebar, setTabState })
 	};
 
 	const addCurrentLatexToBookmark = () => {
-		dispatch(addBookmarkItem());
+		dispatch(addBookmarkItem(latexInput));
 	};
 
 	const handleDeleteButton = index => () => {

--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -24,6 +24,7 @@ export default function BookmarkContainer({ onScroll, setSidebar, setTabState })
 	};
 
 	const addCurrentLatexToBookmark = () => {
+		if (!latexInput) return;
 		dispatch(addBookmarkItem(latexInput));
 	};
 

--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -27,21 +27,21 @@ export default function BookmarkContainer({ onScroll, setSidebar, setTabState })
 		dispatch(addBookmarkItem(latexInput));
 	};
 
-	const handleDeleteButton = index => () => {
-		dispatch(deleteBookmarkItem(index));
+	const handleDeleteButton = id => () => {
+		dispatch(deleteBookmarkItem(id));
 	};
 
 	return (
 		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"북마크 수식 목록"} />
 			{bookmarkItems.length ?
-				bookmarkItems.map((val, index) =>
+				bookmarkItems.map(({ id, latex }) =>
 					<ListItem
-						key={index}
-						latex={val.latex}
-						customOnClick={handleCustomButtonClick(val.latex)}
-						intoLatexFieldOnClick={handleFormulaClick(val.latex)}
-						deleteOnClick={handleDeleteButton(index)}
+						key={id}
+						latex={latex}
+						customOnClick={handleCustomButtonClick(latex)}
+						intoLatexFieldOnClick={handleFormulaClick(latex)}
+						deleteOnClick={handleDeleteButton(id)}
 					/>,
 				) :
 				<EmptyItem content="북마크 수식이 없습니다."/>

--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -29,7 +29,9 @@ export default function BookmarkContainer({ onScroll, setSidebar, setTabState })
 	};
 
 	const handleDeleteButton = id => () => {
-		dispatch(deleteBookmarkItem(id));
+		if (confirm("정말로 삭제하시겠습니까?")) {
+			dispatch(deleteBookmarkItem(id));
+		}
 	};
 
 	return (

--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -1,14 +1,13 @@
 import React from "react";
-
 import { useDispatch, useSelector } from "react-redux";
-import { addBookmarkItem, deleteBookmarkItem, setCustomFormValue, setLatexInput } from "../slice";
 
+import { addBookmarkItem, deleteBookmarkItem, setCustomFormValue, setLatexInput } from "../slice";
+import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 import BookmarkAddButton from "../presentationals/BookmarkAddButton";
 import EmptyItem from "../presentationals/EmptyItem";
-import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 
 export default function BookmarkContainer({ onScroll, setSidebar, setTabState }) {
 	const dispatch = useDispatch();

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -38,7 +38,7 @@ export default function FooterContainer() {
 
 		const virtualCopyTarget = document.createElement("textarea");
 
-		const parameter = latexInput.replace(/\\/g, "$$$");
+		const parameter = latexInput.replace(/\\/g, "@");
 
 		virtualCopyTarget.value = `${location.origin}/${parameter}`;
 

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -52,6 +52,7 @@ export default function FooterContainer() {
 	};
 
 	const handleSaveFormula = () => {
+		if (!latexInput) return;
 		dispatch(addRecentItem(latexInput));
 		dispatch(openBubblePopup({ target: "formulaSave", isOpen: true }));
 	};

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 import html2canvas from "html2canvas";
 
-import { openBubblePopup } from "../slice";
+import { openBubblePopup, addRecentItem } from "../slice";
 import FooterLayout from "../layouts/FooterLayout";
 import FooterButton from "../presentationals/FooterButton";
 
@@ -52,12 +52,7 @@ export default function FooterContainer() {
 	};
 
 	const handleSaveFormula = () => {
-		// store로부터 상태를 불러와야 함.
-		const previousValue = ["a", "b", "c"];
-
-		localStorage.setItem("recentItems", JSON.stringify([latexInput, ...previousValue]));
-
-		// recentItems의 상태를 변경하는 dispatch 로직이 들어가야 함.
+		dispatch(addRecentItem(latexInput));
 		dispatch(openBubblePopup({ target: "formulaSave", isOpen: true }));
 	};
 

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -1,11 +1,17 @@
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import { deleteRecentItem } from "../slice";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
+import EmptyItem from "../presentationals/EmptyItem";
 
 export default function RecentContainer({ onScroll }) {
-	const recentItems = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }, { id: 3, latex: "6 + 7" }, { id: 4, latex: "6 + 7" }];
+	// const items = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }, { id: 3, latex: "6 + 7" }, { id: 4, latex: "6 + 7" }];
+
+	const { recentItems } = useSelector(state => state);
+	const dispatch = useDispatch();
 
 	const handleBookmarkButtonClick = () => {
 		console.log("bookmark");
@@ -15,17 +21,26 @@ export default function RecentContainer({ onScroll }) {
 		console.log("custom");
 	};
 
+	const handleDeleteButtonClick = id => () => {
+		if (confirm("정말로 삭제하시겠습니까?")) {
+			dispatch(deleteRecentItem(id));
+		}
+	};
+
 	return (
 		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"최근 수식 목록"} />
-			{recentItems.map(({ id, latex }) =>
-				<ListItem
-					key={id}
-					latex={latex}
-					bookmarkOnClick={handleBookmarkButtonClick}
-					customOnClick={handleCustomButtonClick}
-				/>,
-			)}
+			{recentItems.length ?
+				recentItems.map(({ id, latex }) =>
+					<ListItem
+						key={id}
+						latex={latex}
+						bookmarkOnClick={handleBookmarkButtonClick}
+						customOnClick={handleCustomButtonClick}
+						deleteOnClick={handleDeleteButtonClick(id)}
+					/>,
+				) :
+				<EmptyItem content={"최근 저장한 수식이 없습니다"}/>}
 		</ListLayout>
 	);
 }

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { deleteRecentItem, addBookmarkItem } from "../slice";
+import { deleteRecentItem, setBookmarkItem } from "../slice";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
@@ -11,8 +11,8 @@ export default function RecentContainer({ onScroll, setTabState }) {
 	const { recentItems } = useSelector(state => state);
 	const dispatch = useDispatch();
 
-	const handleBookmarkButtonClick = latex => () => {
-		dispatch(addBookmarkItem(latex));
+	const handleBookmarkButtonClick = (id, isBookmark) => () => {
+		dispatch(setBookmarkItem({ id, isBookmark: !isBookmark }));
 		setTabState(1);
 	};
 
@@ -34,7 +34,7 @@ export default function RecentContainer({ onScroll, setTabState }) {
 					<ListItem
 						key={id}
 						latex={latex}
-						bookmarkOnClick={handleBookmarkButtonClick(id)}
+						bookmarkOnClick={handleBookmarkButtonClick(id, isBookmark)}
 						customOnClick={handleCustomButtonClick}
 						deleteOnClick={handleDeleteButtonClick(id)}
 						isBookmark={isBookmark}

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -20,9 +20,9 @@ export default function RecentContainer({ onScroll, setTabState }) {
 		console.log("custom");
 	};
 
-	const handleDeleteButtonClick = index => () => {
+	const handleDeleteButtonClick = id => () => {
 		if (confirm("정말로 삭제하시겠습니까?")) {
-			dispatch(deleteRecentItem(index));
+			dispatch(deleteRecentItem(id));
 		}
 	};
 

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { deleteRecentItem, setBookmarkItem } from "../slice";
+import { deleteRecentItem, setBookmarkItem, setLatexInput } from "../slice";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 import EmptyItem from "../presentationals/EmptyItem";
 
-export default function RecentContainer({ onScroll, setTabState }) {
+export default function RecentContainer({ onScroll, setTabState, setSidebar }) {
 	const { recentItems } = useSelector(state => state);
 	const dispatch = useDispatch();
 
@@ -26,6 +26,11 @@ export default function RecentContainer({ onScroll, setTabState }) {
 		}
 	};
 
+	const handleFormulaClick = latex => () => {
+		dispatch(setLatexInput(latex));
+		setSidebar(false);
+	};
+
 	return (
 		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"최근 수식 목록"} />
@@ -37,6 +42,7 @@ export default function RecentContainer({ onScroll, setTabState }) {
 						bookmarkOnClick={handleBookmarkButtonClick(id, isBookmark)}
 						customOnClick={handleCustomButtonClick}
 						deleteOnClick={handleDeleteButtonClick(id)}
+						intoLatexFieldOnClick={handleFormulaClick(latex)}
 						isBookmark={isBookmark}
 					/>,
 				) :

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { deleteRecentItem, setBookmarkItem, setLatexInput } from "../slice";
+import { BOOKMARK_TAB } from "../constants/sidebarTab";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
@@ -13,7 +14,7 @@ export default function RecentContainer({ onScroll, setTabState, setSidebar }) {
 
 	const handleBookmarkButtonClick = (id, isBookmark) => () => {
 		dispatch(setBookmarkItem({ id, isBookmark: !isBookmark }));
-		setTabState(1);
+		setTabState(BOOKMARK_TAB);
 	};
 
 	const handleCustomButtonClick = () => {

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -30,13 +30,14 @@ export default function RecentContainer({ onScroll, setTabState }) {
 		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"최근 수식 목록"} />
 			{recentItems.length ?
-				recentItems.map((value, index) =>
+				recentItems.map(({ id, latex, isBookmark }) =>
 					<ListItem
-						key={index}
-						latex={value.latex}
-						bookmarkOnClick={handleBookmarkButtonClick(value.latex)}
+						key={id}
+						latex={latex}
+						bookmarkOnClick={handleBookmarkButtonClick(id)}
 						customOnClick={handleCustomButtonClick}
-						deleteOnClick={handleDeleteButtonClick(index)}
+						deleteOnClick={handleDeleteButtonClick(id)}
+						isBookmark={isBookmark}
 					/>,
 				) :
 				<EmptyItem content={"최근 저장한 수식이 없습니다"}/>}

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -1,29 +1,28 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { deleteRecentItem } from "../slice";
+import { deleteRecentItem, addBookmarkItem } from "../slice";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 import EmptyItem from "../presentationals/EmptyItem";
 
-export default function RecentContainer({ onScroll }) {
-	// const items = [{ id: 0, latex: "2 + 3" }, { id: 1, latex: "4 + 5" }, { id: 2, latex: "6 + 7" }, { id: 3, latex: "6 + 7" }, { id: 4, latex: "6 + 7" }];
-
+export default function RecentContainer({ onScroll, setTabState }) {
 	const { recentItems } = useSelector(state => state);
 	const dispatch = useDispatch();
 
-	const handleBookmarkButtonClick = () => {
-		console.log("bookmark");
+	const handleBookmarkButtonClick = latex => () => {
+		dispatch(addBookmarkItem(latex));
+		setTabState(1);
 	};
 
 	const handleCustomButtonClick = () => {
 		console.log("custom");
 	};
 
-	const handleDeleteButtonClick = id => () => {
+	const handleDeleteButtonClick = index => () => {
 		if (confirm("정말로 삭제하시겠습니까?")) {
-			dispatch(deleteRecentItem(id));
+			dispatch(deleteRecentItem(index));
 		}
 	};
 
@@ -31,13 +30,13 @@ export default function RecentContainer({ onScroll }) {
 		<ListLayout onScroll={onScroll}>
 			<SideBarHeader title={"최근 수식 목록"} />
 			{recentItems.length ?
-				recentItems.map(({ id, latex }) =>
+				recentItems.map((value, index) =>
 					<ListItem
-						key={id}
-						latex={latex}
-						bookmarkOnClick={handleBookmarkButtonClick}
+						key={index}
+						latex={value.latex}
+						bookmarkOnClick={handleBookmarkButtonClick(value.latex)}
 						customOnClick={handleCustomButtonClick}
-						deleteOnClick={handleDeleteButtonClick(id)}
+						deleteOnClick={handleDeleteButtonClick(index)}
 					/>,
 				) :
 				<EmptyItem content={"최근 저장한 수식이 없습니다"}/>}

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -1,17 +1,18 @@
 import React, { useState } from "react";
 
-import SideBarLayout from "../layouts/SideBarLayout";
-import SideBarTab from "../presentationals/SideBarTab";
-import IconButton from "../presentationals/IconButton";
+import { toFitSimple } from "../util";
+import { RECENT_TAB, BOOKMARK_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import RecentContainer from "./RecentContainer";
 import BookmarkContainer from "./BookmarkContainer";
 import CustomContainer from "./CustomContainer";
 import GreaterThanIcon from "../icons/GreaterThanIcon";
 import LessThanIcon from "../icons/LessThanIcon";
-import { toFitSimple } from "../util";
+import SideBarLayout from "../layouts/SideBarLayout";
+import SideBarTab from "../presentationals/SideBarTab";
+import IconButton from "../presentationals/IconButton";
 
 export default function SideBar() {
-	const [tabState, setTabState] = useState(0);
+	const [tabState, setTabState] = useState(RECENT_TAB);
 	const [isOpenSidebar, setIsOpenSidebar] = useState(false);
 	const [isScrollTop, setIsScrollTop] = useState(true);
 
@@ -20,15 +21,20 @@ export default function SideBar() {
 	};
 
 	const tabMap = {
-		0: <RecentContainer
-			onScroll={toFitSimple(handleSidebarScroll)}
-			setSidebar={setIsOpenSidebar}
-			setTabState={setTabState}/>,
-		1: <BookmarkContainer
-			onScroll={toFitSimple(handleSidebarScroll)}
-			setSidebar={setIsOpenSidebar}
-			setTabState={setTabState}/>,
-		2: <CustomContainer />,
+		[RECENT_TAB]:
+			<RecentContainer
+				onScroll={toFitSimple(handleSidebarScroll)}
+				setSidebar={setIsOpenSidebar}
+				setTabState={setTabState}
+			/>,
+		[BOOKMARK_TAB]:
+			<BookmarkContainer
+				onScroll={toFitSimple(handleSidebarScroll)}
+				setSidebar={setIsOpenSidebar}
+				setTabState={setTabState}
+			/>,
+		[CUSTOM_COMMAND_TAB]:
+			<CustomContainer />,
 	};
 
 	const handleToggleSidebar = () => {

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -22,6 +22,7 @@ export default function SideBar() {
 	const tabMap = {
 		0: <RecentContainer
 			onScroll={toFitSimple(handleSidebarScroll)}
+			setSidebar={setIsOpenSidebar}
 			setTabState={setTabState}/>,
 		1: <BookmarkContainer
 			onScroll={toFitSimple(handleSidebarScroll)}

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -20,7 +20,9 @@ export default function SideBar() {
 	};
 
 	const tabMap = {
-		0: <RecentContainer onScroll={toFitSimple(handleSidebarScroll)}/>,
+		0: <RecentContainer
+			onScroll={toFitSimple(handleSidebarScroll)}
+			setTabState={setTabState}/>,
 		1: <BookmarkContainer
 			onScroll={toFitSimple(handleSidebarScroll)}
 			setSidebar={setIsOpenSidebar}

--- a/src/presentationals/ListItem.jsx
+++ b/src/presentationals/ListItem.jsx
@@ -38,6 +38,7 @@ const Formula = styled.div`
 	left: 50%;
 	top: 50%;
 	transform: translate(-50%, -50%);
+	cursor: pointer;
 `;
 
 const DeleteButton = styled.div`

--- a/src/presentationals/ListItem.jsx
+++ b/src/presentationals/ListItem.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { color } from "../GlobalStyle";
 import EmptyStarIcon from "../icons/EmptyStarIcon";
+import FilledStarIcon from "../icons/FilledStarIcon";
 import PlusIcon from "../icons/PlusIcon";
 import CloseIcon from "../icons/CloseIcon";
 import IconButton from "./IconButton";
@@ -52,6 +53,7 @@ export default function ListItem({
 	bookmarkOnClick,
 	customOnClick,
 	intoLatexFieldOnClick,
+	isBookmark,
 }) {
 	return (
 		<Layout>
@@ -69,7 +71,9 @@ export default function ListItem({
 					<IconButton
 						onClick={bookmarkOnClick}
 						isHover={true}
-						icon={<EmptyStarIcon fill={color.yellow} />}
+						icon={isBookmark ?
+							<FilledStarIcon /> :
+							<EmptyStarIcon fill={color.yellow} />}
 					/>
 				}
 				<IconButton

--- a/src/presentationals/SideBarTab.jsx
+++ b/src/presentationals/SideBarTab.jsx
@@ -10,7 +10,7 @@ import IconButton from "../presentationals/IconButton";
 const TabLayout = styled.div`
 	display: flex;
 	justify-content: space-around;
-	padding-top: 10px;
+	padding: 10px 0 3px 0;
 	z-index: 1000;
 	position: relative;
 	box-shadow: ${({ isScrollTop }) => (isScrollTop ? "none" : "0 12px 15px -15px grey")};
@@ -20,7 +20,6 @@ const TabLayout = styled.div`
 const Tab = styled.div`
 	${({ isSelected }) => (isSelected &&
 		`
-			border-bottom: 3px solid ${color.normal};
 			button {
 				cursor: default;
 			}
@@ -31,11 +30,22 @@ const Tab = styled.div`
 	)}
 `;
 
+const SelectedTabBorderBottom = styled.div`
+	width: 42px;
+	height: 3px;
+	background-color: ${color.normal};
+	position: absolute;
+	left: ${({ currentTab }) => (currentTab * 90) + 24}px;
+	top: 47px;
+	transition: 0.3s;
+`;
+
 export default function SideBarTab({ currentTab, onClick, isScrollTop }) {
 	const tabMenus = [<TimeIcon key="0"/>, <EmptyStarIcon key="1"/>, <CustomIcon key="2"/>];
 
 	return (
 		<TabLayout isScrollTop={isScrollTop}>
+			<SelectedTabBorderBottom currentTab={currentTab} />
 			{tabMenus.map((tabMenu, index) =>
 				<Tab onClick={onClick(index)} key={index} isSelected={currentTab === index}>
 					<IconButton isHover={currentTab !== index} icon={tabMenu} />

--- a/src/presentationals/SideBarTab.jsx
+++ b/src/presentationals/SideBarTab.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { color } from "../GlobalStyle";
+import { RECENT_TAB, BOOKMARK_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import TimeIcon from "../icons/TimeIcon";
 import EmptyStarIcon from "../icons/EmptyStarIcon";
 import CustomIcon from "../icons/CustomIcon";
@@ -41,7 +42,11 @@ const SelectedTabBorderBottom = styled.div`
 `;
 
 export default function SideBarTab({ currentTab, onClick, isScrollTop }) {
-	const tabMenus = [<TimeIcon key="0"/>, <EmptyStarIcon key="1"/>, <CustomIcon key="2"/>];
+	const tabMenus = [
+		<TimeIcon key={RECENT_TAB}/>,
+		<EmptyStarIcon key={BOOKMARK_TAB}/>,
+		<CustomIcon key={CUSTOM_COMMAND_TAB}/>,
+	];
 
 	return (
 		<TabLayout isScrollTop={isScrollTop}>

--- a/src/slice.js
+++ b/src/slice.js
@@ -15,6 +15,7 @@ const { reducer, actions } = createSlice({
 		alignInfo: "center",
 		customCommand: "",
 		bookmarkItems: JSON.parse(localStorage.getItem("bookmarkItems")) || [],
+		recentItems: JSON.parse(localStorage.getItem("recentItems")) || [],
 	},
 	reducers: {
 		setSelectedButton(state, { payload }) {
@@ -67,6 +68,10 @@ const { reducer, actions } = createSlice({
 			state.bookmarkItems = state.bookmarkItems.filter((value, index) => index !== payload);
 			localStorage.setItem("bookmarkItems", JSON.stringify(state.bookmarkItems));
 		},
+		deleteRecentItem(state, { payload }) {
+			state.recentItems = state.recentItems.filter(({ id }) => id !== payload.id);
+			localStorage.setItem("recentItems", JSON.stringify(state.recentItems));
+		},
 	},
 });
 
@@ -82,6 +87,7 @@ export const {
 	setCustomCommand,
 	addBookmarkItem,
 	deleteBookmarkItem,
+	deleteRecentItem,
 } = actions;
 
 export default reducer;

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,6 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-const RECENT_ITEMS = "recentItems";
 const BOOKMARK_ITEMS = "bookmarkItems";
 const LATEX_LIST = "latexList";
 
@@ -8,8 +7,10 @@ const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringif
 const getLocalStorage = key => JSON.parse(localStorage.getItem(key)) || [];
 const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
 const updateSidebar = state => {
+	state.latexList = state.latexList.filter(item => item.isRecent || item.isBookmark);
 	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
 	state.recentItems = state.latexList.filter(item => item.isRecent);
+	saveLocalStorage(LATEX_LIST, state.latexList);
 };
 
 const latexList = getLocalStorage(LATEX_LIST);
@@ -92,7 +93,6 @@ const { reducer, actions } = createSlice({
 			const index = state.latexList.findIndex(({ id }) => id === payload.id);
 			state.latexList[index].isBookmark = payload.isBookmark;
 			updateSidebar(state);
-			saveLocalStorage(LATEX_LIST, state.latexList);
 		},
 		addRecentItem(state, { payload }) {
 			if (!payload) return;
@@ -105,11 +105,12 @@ const { reducer, actions } = createSlice({
 
 			state.latexList.push(newItem);
 			updateSidebar(state);
-			saveLocalStorage(LATEX_LIST, state.latexList);
 		},
 		deleteRecentItem(state, { payload }) {
-			state.recentItems = state.recentItems.filter((_, index) => index !== payload);
-			saveLocalStorage(RECENT_ITEMS, state.recentItems);
+			const index = state.latexList.findIndex(({ id }) => id === payload);
+
+			state.latexList[index].isRecent = false;
+			updateSidebar(state);
 		},
 		setBubblePopupOn(state, { payload }) {
 			const { target, isOpen } = payload;

--- a/src/slice.js
+++ b/src/slice.js
@@ -2,8 +2,13 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const RECENT_ITEMS = "recentItems";
 const BOOKMARK_ITEMS = "bookmarkItems";
+const LATEX_LIST = "latexList";
+
 const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
 const getLocalStorage = key => JSON.parse(localStorage.getItem(key)) || [];
+const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
+
+const latexList = getLocalStorage(LATEX_LIST);
 
 const { reducer, actions } = createSlice({
 	name: "FEditor",
@@ -19,13 +24,14 @@ const { reducer, actions } = createSlice({
 		},
 		alignInfo: "center",
 		customCommand: "",
-		bookmarkItems: getLocalStorage(BOOKMARK_ITEMS),
-		recentItems: getLocalStorage(RECENT_ITEMS),
 		bubblePopup: {
 			imageDownload: false,
 			linkCopy: false,
 			formulaSave: false,
 		},
+		latexList,
+		bookmarkItems: latexList.filter(item => item.isBookmark),
+		recentItems: latexList.filter(item => item.isRecent),
 	},
 	reducers: {
 		setSelectedButton(state, { payload }) {
@@ -78,6 +84,19 @@ const { reducer, actions } = createSlice({
 			state.bookmarkItems = state.bookmarkItems.filter((value, index) => index !== payload);
 			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
 		},
+		addRecentItem(state, { payload }) {
+			if (!payload) return;
+			const newItem = {
+				id: getIdToAdd(state.latexList),
+				latex: payload,
+				isRecent: true,
+				isBookmark: false,
+			};
+
+			state.latexList.push(newItem);
+			state.recentItems.push(newItem);
+			saveLocalStorage(LATEX_LIST, state.latexList);
+		},
 		deleteRecentItem(state, { payload }) {
 			state.recentItems = state.recentItems.filter((_, index) => index !== payload);
 			saveLocalStorage(RECENT_ITEMS, state.recentItems);
@@ -102,6 +121,7 @@ export const {
 	setCustomCommand,
 	addBookmarkItem,
 	deleteBookmarkItem,
+	addRecentItem,
 	deleteRecentItem,
 	setBubblePopupOn,
 } = actions;

--- a/src/slice.js
+++ b/src/slice.js
@@ -7,6 +7,10 @@ const LATEX_LIST = "latexList";
 const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
 const getLocalStorage = key => JSON.parse(localStorage.getItem(key)) || [];
 const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
+const updateSidebar = state => {
+	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
+	state.recentItems = state.latexList.filter(item => item.isRecent);
+};
 
 const latexList = getLocalStorage(LATEX_LIST);
 
@@ -84,6 +88,12 @@ const { reducer, actions } = createSlice({
 			state.bookmarkItems = state.bookmarkItems.filter((value, index) => index !== payload);
 			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
 		},
+		setBookmarkItem(state, { payload }) {
+			const index = state.latexList.findIndex(({ id }) => id === payload.id);
+			state.latexList[index].isBookmark = payload.isBookmark;
+			updateSidebar(state);
+			saveLocalStorage(LATEX_LIST, state.latexList);
+		},
 		addRecentItem(state, { payload }) {
 			if (!payload) return;
 			const newItem = {
@@ -94,7 +104,7 @@ const { reducer, actions } = createSlice({
 			};
 
 			state.latexList.push(newItem);
-			state.recentItems.push(newItem);
+			updateSidebar(state);
 			saveLocalStorage(LATEX_LIST, state.latexList);
 		},
 		deleteRecentItem(state, { payload }) {
@@ -121,6 +131,7 @@ export const {
 	setCustomCommand,
 	addBookmarkItem,
 	deleteBookmarkItem,
+	setBookmarkItem,
 	addRecentItem,
 	deleteRecentItem,
 	setBubblePopupOn,

--- a/src/slice.js
+++ b/src/slice.js
@@ -86,11 +86,14 @@ const { reducer, actions } = createSlice({
 			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
 		},
 		deleteBookmarkItem(state, { payload }) {
-			state.bookmarkItems = state.bookmarkItems.filter((value, index) => index !== payload);
-			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
+			const index = state.latexList.findIndex(({ id }) => id === payload);
+
+			state.latexList[index].isBookmark = false;
+			updateSidebar(state);
 		},
 		setBookmarkItem(state, { payload }) {
 			const index = state.latexList.findIndex(({ id }) => id === payload.id);
+
 			state.latexList[index].isBookmark = payload.isBookmark;
 			updateSidebar(state);
 		},

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,6 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-const BOOKMARK_ITEMS = "bookmarkItems";
 const LATEX_LIST = "latexList";
 
 const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
@@ -11,6 +10,12 @@ const updateSidebar = state => {
 	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
 	state.recentItems = state.latexList.filter(item => item.isRecent);
 	saveLocalStorage(LATEX_LIST, state.latexList);
+};
+const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
+	const id = getIdToAdd(state.latexList);
+	const newItem = { id, latex, isRecent, isBookmark };
+
+	state.latexList.push(newItem);
 };
 
 const latexList = getLocalStorage(LATEX_LIST);
@@ -82,8 +87,8 @@ const { reducer, actions } = createSlice({
 		},
 		addBookmarkItem(state, { payload }) {
 			if (!payload) return;
-			state.bookmarkItems.push({ latex: payload });
-			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
+			addLatexItem(state, { latex: payload, isBookmark: true });
+			updateSidebar(state);
 		},
 		deleteBookmarkItem(state, { payload }) {
 			const index = state.latexList.findIndex(({ id }) => id === payload);
@@ -99,14 +104,7 @@ const { reducer, actions } = createSlice({
 		},
 		addRecentItem(state, { payload }) {
 			if (!payload) return;
-			const newItem = {
-				id: getIdToAdd(state.latexList),
-				latex: payload,
-				isRecent: true,
-				isBookmark: false,
-			};
-
-			state.latexList.push(newItem);
+			addLatexItem(state, { latex: payload, isRecent: true });
 			updateSidebar(state);
 		},
 		deleteRecentItem(state, { payload }) {

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,24 +1,13 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-const LATEX_LIST = "latexList";
+import {
+	LATEX_LIST,
+	getLocalStorage,
+	updateSidebar,
+	addLatexItem,
+} from "./util";
 
-const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
-const getLocalStorage = key => JSON.parse(localStorage.getItem(key)) || [];
-const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
-const updateSidebar = state => {
-	state.latexList = state.latexList.filter(item => item.isRecent || item.isBookmark);
-	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
-	state.recentItems = state.latexList.filter(item => item.isRecent);
-	saveLocalStorage(LATEX_LIST, state.latexList);
-};
-const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
-	const id = getIdToAdd(state.latexList);
-	const newItem = { id, latex, isRecent, isBookmark };
-
-	state.latexList.push(newItem);
-};
-
-const latexList = getLocalStorage(LATEX_LIST);
+const latexList = getLocalStorage(LATEX_LIST, []);
 
 const { reducer, actions } = createSlice({
 	name: "FEditor",

--- a/src/slice.js
+++ b/src/slice.js
@@ -75,7 +75,6 @@ const { reducer, actions } = createSlice({
 			state.customCommand = payload;
 		},
 		addBookmarkItem(state, { payload }) {
-			if (!payload) return;
 			addLatexItem(state, { latex: payload, isBookmark: true });
 			updateSidebar(state);
 		},
@@ -92,7 +91,6 @@ const { reducer, actions } = createSlice({
 			updateSidebar(state);
 		},
 		addRecentItem(state, { payload }) {
-			if (!payload) return;
 			addLatexItem(state, { latex: payload, isRecent: true });
 			updateSidebar(state);
 		},

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,5 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+const RECENT_ITEMS = "recentItems";
+const BOOKMARK_ITEMS = "bookmarkItems";
+const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+const getLocalStorage = key => JSON.parse(localStorage.getItem(key)) || [];
+
 const { reducer, actions } = createSlice({
 	name: "FEditor",
 	initialState: {
@@ -14,8 +19,8 @@ const { reducer, actions } = createSlice({
 		},
 		alignInfo: "center",
 		customCommand: "",
-		bookmarkItems: JSON.parse(localStorage.getItem("bookmarkItems")) || [],
-		recentItems: JSON.parse(localStorage.getItem("recentItems")) || [],
+		bookmarkItems: getLocalStorage(BOOKMARK_ITEMS),
+		recentItems: getLocalStorage(RECENT_ITEMS),
 	},
 	reducers: {
 		setSelectedButton(state, { payload }) {
@@ -59,18 +64,18 @@ const { reducer, actions } = createSlice({
 		setCustomCommand(state, { payload }) {
 			state.customCommand = payload;
 		},
-		addBookmarkItem(state) {
-			if (state.latexInput.length === 0) return;
-			state.bookmarkItems.push({ latex: state.latexInput });
-			localStorage.setItem("bookmarkItems", JSON.stringify(state.bookmarkItems));
+		addBookmarkItem(state, { payload }) {
+			if (!payload) return;
+			state.bookmarkItems.push({ latex: payload });
+			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
 		},
 		deleteBookmarkItem(state, { payload }) {
 			state.bookmarkItems = state.bookmarkItems.filter((value, index) => index !== payload);
-			localStorage.setItem("bookmarkItems", JSON.stringify(state.bookmarkItems));
+			saveLocalStorage(BOOKMARK_ITEMS, state.bookmarkItems);
 		},
 		deleteRecentItem(state, { payload }) {
-			state.recentItems = state.recentItems.filter(({ id }) => id !== payload.id);
-			localStorage.setItem("recentItems", JSON.stringify(state.recentItems));
+			state.recentItems = state.recentItems.filter((_, index) => index !== payload);
+			saveLocalStorage(RECENT_ITEMS, state.recentItems);
 		},
 	},
 });

--- a/src/util.js
+++ b/src/util.js
@@ -12,3 +12,28 @@ export const toFitSimple = cb => {
 		});
 	};
 };
+
+/* local storage 관련 모듈 */
+
+export const LATEX_LIST = "latexList";
+
+export const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+
+export const getLocalStorage = (key, defaultValue) =>
+	JSON.parse(localStorage.getItem(key)) || defaultValue;
+
+export const updateSidebar = state => {
+	state.latexList = state.latexList.filter(item => item.isRecent || item.isBookmark);
+	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
+	state.recentItems = state.latexList.filter(item => item.isRecent);
+	saveLocalStorage(LATEX_LIST, state.latexList);
+};
+
+export const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
+
+export const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
+	const id = getIdToAdd(state.latexList);
+	const newItem = { id, latex, isRecent, isBookmark };
+
+	state.latexList.push(newItem);
+};

--- a/test/presentationals/SideBarTab.test.jsx
+++ b/test/presentationals/SideBarTab.test.jsx
@@ -8,8 +8,10 @@ describe("<SideBarTab />", () => {
 	it("renders tab menu", () => {
 		const onClick = () => () => {};
 		const { container } = render(<SideBarTab onClick={onClick}/>);
+		const div = container.querySelectorAll("div");
 		const tabMenus = container.querySelectorAll("button");
 
+		expect(div).toHaveLength(5);
 		expect(tabMenus).toHaveLength(3);
 	});
 });


### PR DESCRIPTION
## 변경사항
- 사이드바 탭버튼 선택시 밑줄 이동 애니메이션 구현
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/43347250/100832603-8e840200-34ab-11eb-8136-4779934a704d.gif)
- 컴포넌트 변경에 따른 테스트 코드 수정
- 최근 수식 / 북마크 리스트 상태 리팩토링
  - 최근 수식과 북마크 탭에서 상태관리를 따로 했는데, 최근 수식 아이템이 북마크가 등록되었는지 알려면 하나의 상태로 관리해야함을 깨닫고 리팩토링
  - 상태 변경에 따른 `slice.js`의 reducer 함수 전체적으로 리팩토링
- 기존 `tabState`를 숫자로 관리했는데, 치현님이 분리해주신 `sidebarTab` 상수로 변경
- 북마크 아이템 삭제시 confirm 팝업
- 메인 페이지에서 링크 복사시 `\`를 `@`로 변경하기로 했는데 불러와서 렌더링 부분은 바뀌었고, 링크 저장시에는 안바뀌어있어서 수정

## 추가사항
- 메인 페이지에서 하단 버튼 최근 수식 저장하기 기능 구현
- 최근 수식 탭에서 최근 수식 삭제하기 기능 구현
- 최근 수식 탭에서 해당 수식 북마크 등록/해제
- 최근 수식 탭에서 수식 클릭시 메인 페이지에 렌더링 및 사이드탭 닫기 

## 미리보기
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/43347250/100834349-17e90380-34af-11eb-8ccb-f7cd14e42ae1.gif)