### PR TITLE
디바운스를 이용한 임시저장 로직 구현

### DIFF
--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { setLatexInput, setLatexTextInput } from "../slice";
+import { setLatexInputWithDibounce, setLatexTextInputWithDibounce } from "../slice";
 
 import FontContainer from "./FontContainer";
 import ControlButtonContainer from "./ControlButtonContainer";
@@ -20,7 +20,7 @@ export default function BodyContainer() {
 		alignInfo,
 	} = useSelector(state => state);
 
-	const handleLatexInput = mathField => dispatch(setLatexInput(mathField.latex()));
+	const handleLatexInput = mathField => dispatch(setLatexInputWithDibounce(mathField.latex()));
 
 
 	const setUpLatexInsertFunction = mathField => {
@@ -30,7 +30,7 @@ export default function BodyContainer() {
 	};
 
 	const handleLatexTextarea = e => {
-		dispatch(setLatexTextInput(e.target.value));
+		dispatch(setLatexTextInputWithDibounce(e.target.value));
 	};
 
 	return (

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { setLatexInputWithDibounce, setLatexTextInputWithDibounce } from "../slice";
+import { setLatexInputWithDebounce, setLatexTextInputWithDebounce } from "../slice";
 
 import FontContainer from "./FontContainer";
 import ControlButtonContainer from "./ControlButtonContainer";
@@ -20,7 +20,7 @@ export default function BodyContainer() {
 		alignInfo,
 	} = useSelector(state => state);
 
-	const handleLatexInput = mathField => dispatch(setLatexInputWithDibounce(mathField.latex()));
+	const handleLatexInput = mathField => dispatch(setLatexInputWithDebounce(mathField.latex()));
 
 
 	const setUpLatexInsertFunction = mathField => {
@@ -30,7 +30,7 @@ export default function BodyContainer() {
 	};
 
 	const handleLatexTextarea = e => {
-		dispatch(setLatexTextInputWithDibounce(e.target.value));
+		dispatch(setLatexTextInputWithDebounce(e.target.value));
 	};
 
 	return (

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -29,7 +29,11 @@ export default function FooterContainer() {
 
 		mathquillArea.style.width = "100%";
 
-		dispatch(openBubblePopup({ target: "imageDownload", isOpen: true }));
+		dispatch(openBubblePopup({
+			target: "imageDownload",
+			isOpen: true,
+			message: "수식을 이미지로 저장하였습니다",
+		}));
 	};
 
 	const handleCopyLink = () => {
@@ -48,7 +52,11 @@ export default function FooterContainer() {
 		document.execCommand("copy");
 		document.body.removeChild(virtualCopyTarget);
 
-		dispatch(openBubblePopup({ target: "linkCopy", isOpen: true }));
+		dispatch(openBubblePopup({
+			target: "linkCopy",
+			isOpen: true,
+			message: "수식 링크를 복사하였습니다",
+		}));
 	};
 
 	const handleSaveFormula = () => {
@@ -58,7 +66,11 @@ export default function FooterContainer() {
 		localStorage.setItem("recentItems", JSON.stringify([latexInput, ...previousValue]));
 
 		// recentItems의 상태를 변경하는 dispatch 로직이 들어가야 함.
-		dispatch(openBubblePopup({ target: "formulaSave", isOpen: true }));
+		dispatch(openBubblePopup({
+			target: "formulaSave",
+			isOpen: true,
+			message: "수식을 저장하였습니다",
+		}));
 	};
 
 	return (
@@ -66,20 +78,20 @@ export default function FooterContainer() {
 			<FooterButton
 				name="이미지로 다운로드"
 				onClick={handleDownloadAsImage}
-				isPopupOn={imageDownload}
-				message="수식을 이미지로 저장하였습니다"
+				isPopupOn={imageDownload.isOpen}
+				message={imageDownload.message}
 			/>
 			<FooterButton
 				name="링크 복사"
 				onClick={handleCopyLink}
-				isPopupOn={linkCopy}
-				message="수식 링크를 복사하였습니다"
+				isPopupOn={linkCopy.isOpen}
+				message={linkCopy.message}
 			/>
 			<FooterButton
 				name="수식 저장"
 				onClick={handleSaveFormula}
-				isPopupOn={formulaSave}
-				message="수식을 저장하였습니다"
+				isPopupOn={formulaSave.isOpen}
+				message={formulaSave.message}
 			/>
 		</FooterLayout>
 	);

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -31,7 +31,6 @@ export default function FooterContainer() {
 
 		dispatch(openBubblePopup({
 			target: "imageDownload",
-			isOpen: true,
 			message: "수식을 이미지로 저장하였습니다",
 		}));
 	};
@@ -54,7 +53,6 @@ export default function FooterContainer() {
 
 		dispatch(openBubblePopup({
 			target: "linkCopy",
-			isOpen: true,
 			message: "수식 링크를 복사하였습니다",
 		}));
 	};
@@ -64,7 +62,6 @@ export default function FooterContainer() {
 		dispatch(addRecentItem(latexInput));
 		dispatch(openBubblePopup({
 			target: "formulaSave",
-			isOpen: true,
 			message: "수식을 저장하였습니다",
 		}));
 	};

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -76,7 +76,7 @@ export default function FooterContainer() {
 				message="수식 링크를 복사하였습니다"
 			/>
 			<FooterButton
-				name="수식 임시저장"
+				name="수식 저장"
 				onClick={handleSaveFormula}
 				isPopupOn={formulaSave}
 				message="수식을 저장하였습니다"

--- a/src/containers/FooterContainer.jsx
+++ b/src/containers/FooterContainer.jsx
@@ -71,19 +71,19 @@ export default function FooterContainer() {
 			<FooterButton
 				name="이미지로 다운로드"
 				onClick={handleDownloadAsImage}
-				isPopupOn={imageDownload.isOpen}
+				isOpen={imageDownload.isOpen}
 				message={imageDownload.message}
 			/>
 			<FooterButton
 				name="링크 복사"
 				onClick={handleCopyLink}
-				isPopupOn={linkCopy.isOpen}
+				isOpen={linkCopy.isOpen}
 				message={linkCopy.message}
 			/>
 			<FooterButton
 				name="수식 저장"
 				onClick={handleSaveFormula}
-				isPopupOn={formulaSave.isOpen}
+				isOpen={formulaSave.isOpen}
 				message={formulaSave.message}
 			/>
 		</FooterLayout>

--- a/src/presentationals/BubblePopup.jsx
+++ b/src/presentationals/BubblePopup.jsx
@@ -13,10 +13,10 @@ const Layout = styled.div`
   ${({ isOpen }) =>
 		(isOpen ? `
       display: block;
-      top: 620px;
+      top: 600px;
     ` : `
       display: block;
-      top: 660px;
+      top: 640px;
     `)}
 `;
 

--- a/src/presentationals/FooterButton.jsx
+++ b/src/presentationals/FooterButton.jsx
@@ -20,10 +20,10 @@ const FooterButtonStyle = styled.button`
 	}
 `;
 
-export default function FooterButton({ name, onClick, isPopupOn, message }) {
+export default function FooterButton({ name, onClick, isOpen, message }) {
 	return (
 		<Layout onClick={onClick}>
-			<BubblePopup isOpen={isPopupOn} message={message} />
+			<BubblePopup isOpen={isOpen} message={message} />
 			<FooterButtonStyle>{name}</FooterButtonStyle>
 		</Layout>
 	);

--- a/src/slice.js
+++ b/src/slice.js
@@ -80,7 +80,7 @@ const { reducer, actions } = createSlice({
 		},
 		setTimerId(state, { payload }) {
 			state.timerId = payload;
-	},
+		},
 	},
 });
 
@@ -97,14 +97,45 @@ export const {
 	addBookmarkItem,
 	deleteBookmarkItem,
 	setCustomFormValue,
+	setTimerId,
 } = actions;
 
 export const openBubblePopup = payload => dispatch => {
 	dispatch(setBubblePopupOn(payload));
 
 	setTimeout(() => {
-		dispatch(setBubblePopupOn({ target: payload.target, isOpen: false }));
+		dispatch(setBubblePopupOn({ ...payload, isOpen: false }));
 	}, 1000);
+};
+
+const startBubblePopupDebounce = (dispatch, getState) => {
+	const state = getState();
+
+	clearTimeout(state.timerId);
+	const timerId = setTimeout(() => {
+		const bubblePopupState = {
+			target: "formulaSave",
+			isOpen: true,
+			message: "임시저장 되었습니다",
+		};
+
+		dispatch(setBubblePopupOn(bubblePopupState));
+		setTimeout(() => {
+			dispatch(setBubblePopupOn({ ...bubblePopupState, isOpen: false }));
+		}, 2000);
+	}, 10000);
+
+	dispatch(setTimerId(timerId));
+};
+
+export const setLatexInputWithDibounce = payload => (dispatch, getState) => {
+	dispatch(setLatexInput(payload));
+	startBubblePopupDebounce(dispatch, getState);
+};
+
+export const setLatexTextInputWithDibounce = payload => (dispatch, getState) => {
+	dispatch(setLatexTextInput(payload));
+	startBubblePopupDebounce(dispatch, getState);
 };
 
 export default reducer;

--- a/src/slice.js
+++ b/src/slice.js
@@ -14,9 +14,9 @@ const { reducer, actions } = createSlice({
 		},
 		alignInfo: "center",
 		bubblePopup: {
-			imageDownload: false,
-			linkCopy: false,
-			formulaSave: false,
+			imageDownload: { isOpen: false, message: "" },
+			linkCopy: { isOpen: false, message: "" },
+			formulaSave: { isOpen: false, message: "" },
 		},
 		bookmarkItems: JSON.parse(localStorage.getItem("bookmarkItems")) || [],
 		customFormValue: { state: false, name: "등록", command: "", latex: "", id: -1, isDisabled: false },
@@ -61,9 +61,9 @@ const { reducer, actions } = createSlice({
 			state.latexInput = "";
 		},
 		setBubblePopupOn(state, { payload }) {
-			const { target, isOpen } = payload;
+			const { target, isOpen, message } = payload;
 
-			state.bubblePopup[target] = isOpen;
+			state.bubblePopup[target] = { isOpen, message };
 		},
 		addBookmarkItem(state) {
 			if (state.latexInput.length === 0) return;

--- a/src/slice.js
+++ b/src/slice.js
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 
 import {
 	LATEX_LIST,
+	INITIAL_ID,
 	getLocalStorage,
 	updateSidebar,
 	addLatexItem,
@@ -28,7 +29,7 @@ const { reducer, actions } = createSlice({
 			linkCopy: { isOpen: false, message: "" },
 			formulaSave: { isOpen: false, message: "" },
 		},
-		tempSavedLatexId: 0,
+		tempSavedLatexId: INITIAL_ID,
 		latexList,
 		bookmarkItems: latexList.filter(item => item.isBookmark),
 		recentItems: latexList.filter(item => item.isRecent),
@@ -126,7 +127,7 @@ const { reducer, actions } = createSlice({
 			state.customFormValue.latex = payload;
 		},
 		setTempSavedItem(state, { payload }) {
-			if (state.tempSavedLatexId === 0) {
+			if (state.tempSavedLatexId === INITIAL_ID) {
 				const id = getIdToAdd(state.latexList);
 				const newItem = { id, latex: state.latexInput, isRecent: true, isBookmark: false };
 
@@ -180,24 +181,28 @@ export const openBubblePopup = payload => dispatch => {
 	}, 1000);
 };
 
+const saveTempItem = dispatch => () => {
+	dispatch(setTempSavedItem());
+
+	const bubblePopupState = {
+		target: "formulaSave",
+		message: "임시저장 되었습니다",
+		isOpen: true,
+	};
+
+	dispatch(setBubblePopupOn(bubblePopupState));
+
+	setTimeout(() => {
+		dispatch(setBubblePopupOn({ ...bubblePopupState, isOpen: false }));
+	}, 2000);
+};
+
 const startBubblePopupDebounce = (dispatch, getState) => {
 	const state = getState();
 
 	clearTimeout(state.timerId);
-	const timerId = setTimeout(() => {
-		dispatch(setTempSavedItem());
 
-		const bubblePopupState = {
-			target: "formulaSave",
-			isOpen: true,
-			message: "임시저장 되었습니다",
-		};
-
-		dispatch(setBubblePopupOn(bubblePopupState));
-		setTimeout(() => {
-			dispatch(setBubblePopupOn({ ...bubblePopupState, isOpen: false }));
-		}, 2000);
-	}, 10000);
+	const timerId = setTimeout(saveTempItem(dispatch), 10000);
 
 	dispatch(setTimerId(timerId));
 };

--- a/src/slice.js
+++ b/src/slice.js
@@ -174,7 +174,7 @@ export const deleteCustomCommand = payload => dispatch => {
 };
 
 export const openBubblePopup = payload => dispatch => {
-	dispatch(setBubblePopupOn(payload));
+	dispatch(setBubblePopupOn({ ...payload, isOpen: true }));
 
 	setTimeout(() => {
 		dispatch(setBubblePopupOn({ ...payload, isOpen: false }));

--- a/src/slice.js
+++ b/src/slice.js
@@ -207,14 +207,13 @@ const startBubblePopupDebounce = (dispatch, getState) => {
 	dispatch(setTimerId(timerId));
 };
 
-export const setLatexInputWithDebounce = payload => (dispatch, getState) => {
-	dispatch(setLatexInput(payload));
+const setDebounce = (actionCreater, payload) => (dispatch, getState) => {
+	dispatch(actionCreater(payload));
 	startBubblePopupDebounce(dispatch, getState);
 };
 
-export const setLatexTextInputWithDebounce = payload => (dispatch, getState) => {
-	dispatch(setLatexTextInput(payload));
-	startBubblePopupDebounce(dispatch, getState);
-};
+export const setLatexInputWithDebounce = payload => setDebounce(setLatexInput, payload);
+
+export const setLatexTextInputWithDebounce = payload => setDebounce(setLatexTextInput, payload);
 
 export default reducer;

--- a/src/slice.js
+++ b/src/slice.js
@@ -97,9 +97,9 @@ const { reducer, actions } = createSlice({
 
 			if (state.tempSavedLatexId !== INITIAL_ID) {
 				state.latexList = state.latexList.filter(({ id }) => id !== state.tempSavedLatexId);
+				state.tempSavedLatexId = INITIAL_ID;
 			}
 
-			state.tempSavedLatexId = 0;
 			clearTimeout(state.timerId);
 			updateSidebar(state);
 		},

--- a/src/slice.js
+++ b/src/slice.js
@@ -202,12 +202,12 @@ const startBubblePopupDebounce = (dispatch, getState) => {
 	dispatch(setTimerId(timerId));
 };
 
-export const setLatexInputWithDibounce = payload => (dispatch, getState) => {
+export const setLatexInputWithDebounce = payload => (dispatch, getState) => {
 	dispatch(setLatexInput(payload));
 	startBubblePopupDebounce(dispatch, getState);
 };
 
-export const setLatexTextInputWithDibounce = payload => (dispatch, getState) => {
+export const setLatexTextInputWithDebounce = payload => (dispatch, getState) => {
 	dispatch(setLatexTextInput(payload));
 	startBubblePopupDebounce(dispatch, getState);
 };

--- a/src/slice.js
+++ b/src/slice.js
@@ -6,7 +6,7 @@ import {
 	updateSidebar,
 	addLatexItem,
 	getIdToAdd,
-} from "./util";
+} from "./sliceUtil";
 
 const latexList = getLocalStorage(LATEX_LIST, []);
 

--- a/src/slice.js
+++ b/src/slice.js
@@ -95,7 +95,7 @@ const { reducer, actions } = createSlice({
 		addRecentItem(state, { payload }) {
 			addLatexItem(state, { latex: payload, isRecent: true });
 
-			if (state.tempSavedLatexId !== 0) {
+			if (state.tempSavedLatexId !== INITIAL_ID) {
 				state.latexList = state.latexList.filter(({ id }) => id !== state.tempSavedLatexId);
 			}
 

--- a/src/slice.js
+++ b/src/slice.js
@@ -173,28 +173,25 @@ export const deleteCustomCommand = payload => dispatch => {
 	dispatch(setCustomCommands(payload.newCustomCommands));
 };
 
-export const openBubblePopup = payload => dispatch => {
-	dispatch(setBubblePopupOn({ ...payload, isOpen: true }));
+const setPopup = (dispatch, config, ms) => {
+	dispatch(setBubblePopupOn({ ...config, isOpen: true }));
 
 	setTimeout(() => {
-		dispatch(setBubblePopupOn({ ...payload, isOpen: false }));
-	}, 1000);
+		dispatch(setBubblePopupOn({ ...config, isOpen: false }));
+	}, ms);
 };
+
+export const openBubblePopup = payload => dispatch => setPopup(dispatch, payload, 1000);
 
 const saveTempItem = dispatch => () => {
 	dispatch(setTempSavedItem());
 
-	const bubblePopupState = {
+	const config = {
 		target: "formulaSave",
 		message: "임시저장 되었습니다",
-		isOpen: true,
 	};
 
-	dispatch(setBubblePopupOn(bubblePopupState));
-
-	setTimeout(() => {
-		dispatch(setBubblePopupOn({ ...bubblePopupState, isOpen: false }));
-	}, 2000);
+	setPopup(dispatch, config, 2000);
 };
 
 const startBubblePopupDebounce = (dispatch, getState) => {

--- a/src/slice.js
+++ b/src/slice.js
@@ -20,6 +20,7 @@ const { reducer, actions } = createSlice({
 		},
 		bookmarkItems: JSON.parse(localStorage.getItem("bookmarkItems")) || [],
 		customFormValue: { state: false, name: "등록", command: "", latex: "", id: -1, isDisabled: false },
+		timerId: "",
 	},
 	reducers: {
 		setSelectedButton(state, { payload }) {
@@ -77,6 +78,9 @@ const { reducer, actions } = createSlice({
 		setCustomFormValue(state, { payload }) {
 			state.customFormValue = payload;
 		},
+		setTimerId(state, { payload }) {
+			state.timerId = payload;
+	},
 	},
 });
 

--- a/src/slice.js
+++ b/src/slice.js
@@ -93,6 +93,13 @@ const { reducer, actions } = createSlice({
 		},
 		addRecentItem(state, { payload }) {
 			addLatexItem(state, { latex: payload, isRecent: true });
+
+			if (state.tempSavedLatexId !== 0) {
+				state.latexList = state.latexList.filter(({ id }) => id !== state.tempSavedLatexId);
+			}
+
+			state.tempSavedLatexId = 0;
+			clearTimeout(state.timerId);
 			updateSidebar(state);
 		},
 		deleteRecentItem(state, { payload }) {

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -1,0 +1,22 @@
+export const LATEX_LIST = "latexList";
+
+export const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+
+export const getLocalStorage = (key, defaultValue) =>
+	JSON.parse(localStorage.getItem(key)) || defaultValue;
+
+export const updateSidebar = state => {
+	state.latexList = state.latexList.filter(item => item.isRecent || item.isBookmark);
+	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
+	state.recentItems = state.latexList.filter(item => item.isRecent);
+	saveLocalStorage(LATEX_LIST, state.latexList);
+};
+
+export const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
+
+export const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
+	const id = getIdToAdd(state.latexList);
+	const newItem = { id, latex, isRecent, isBookmark };
+
+	state.latexList.push(newItem);
+};

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -1,4 +1,5 @@
 export const LATEX_LIST = "latexList";
+export const INITIAL_ID = 0;
 
 export const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
 

--- a/src/util.js
+++ b/src/util.js
@@ -12,28 +12,3 @@ export const toFitSimple = cb => {
 		});
 	};
 };
-
-/* local storage 관련 모듈 */
-
-export const LATEX_LIST = "latexList";
-
-export const saveLocalStorage = (key, value) => localStorage.setItem(key, JSON.stringify(value));
-
-export const getLocalStorage = (key, defaultValue) =>
-	JSON.parse(localStorage.getItem(key)) || defaultValue;
-
-export const updateSidebar = state => {
-	state.latexList = state.latexList.filter(item => item.isRecent || item.isBookmark);
-	state.bookmarkItems = state.latexList.filter(item => item.isBookmark);
-	state.recentItems = state.latexList.filter(item => item.isRecent);
-	saveLocalStorage(LATEX_LIST, state.latexList);
-};
-
-export const getIdToAdd = list => list.reduce((maxId, { id }) => (maxId < id ? id : maxId), 0) + 1;
-
-export const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
-	const id = getIdToAdd(state.latexList);
-	const newItem = { id, latex, isRecent, isBookmark };
-
-	state.latexList.push(newItem);
-};

--- a/test/containers/FooterContainer.test.jsx
+++ b/test/containers/FooterContainer.test.jsx
@@ -14,9 +14,9 @@ describe("<FooterContainer />", () => {
 		useSelector.mockImplementation(selector => selector({
 			latexInput: "3+5",
 			bubblePopup: {
-				imageDownload: null,
-				linkCopy: null,
-				formulaSave: null,
+				imageDownload: { isOpen: false, message: "" },
+				linkCopy: { isOpen: false, message: "" },
+				formulaSave: { isOpen: false, message: "" },
 			},
 		}));
 
@@ -31,7 +31,7 @@ describe("<FooterContainer />", () => {
 
 		const linkCopyButton = getByText("링크 복사");
 		const imageDownloadButton = getByText("이미지로 다운로드");
-		const formulaSaveButton = getByText("수식 임시저장");
+		const formulaSaveButton = getByText("수식 저장");
 
 		expect(linkCopyButton).toBeVisible();
 		expect(imageDownloadButton).toBeVisible();

--- a/test/presentationals/CustomForm.test.jsx
+++ b/test/presentationals/CustomForm.test.jsx
@@ -11,14 +11,15 @@ describe("<CustomForm />", () => {
 			const onClick = () => { };
 			const onSubmit = () => { };
 			const { container } = render(<CustomForm data={data} onChange={onClick} onSubmit={onSubmit} />);
-			const [commandInput, mathquillInput] = container.querySelectorAll("input");
+			const commandInput = container.querySelector("input");
+			const mathfield = container.querySelector(".mq-editable-field");
 			const warningMsg = container.querySelector("p");
 			const submitBtn = container.querySelector("button");
 
 			expect(warningMsg).toHaveStyle("display:none");
 			expect(commandInput.placeholder).toContain("명령어를 다음과 같이 입력하세요");
 			expect(commandInput.value).toBe("\\cmx");
-			expect(mathquillInput.value).toBe("\\sum41");
+			expect(mathfield).toBeVisible();
 			expect(submitBtn).toHaveTextContent("테스트 버튼");
 		});
 	});


### PR DESCRIPTION
## 추가 사항
- 디바운스를 이용해 유저의 동작이 끝나면 10초 후 임시저장하는 로직을 구현

## 변경 사항
- "수식 임시저장" 버튼을 "수식 저장" 버튼으로 이름 변경
- 하단의 버튼에 말풍선 팝업이 가려지는 문제 해결
- 깨지는 테스트 수정

## 구현 내용
아래 GIF는 테스트를 위해 디바운스 텀을 3초로 설정
![Peek 2020-12-02 18-21](https://user-images.githubusercontent.com/59194356/100853597-4c6ab880-34cb-11eb-97d3-5a08328fecb8.gif)
