### PR TITLE
actionCreator 함수 파일 분리 및 커스텀 명령어 실행 방법 변경

### DIFF
--- a/src/actionCreator.js
+++ b/src/actionCreator.js
@@ -1,0 +1,109 @@
+import {
+	INITIAL_ID,
+	updateSidebar,
+	updateCustomCommandList,
+	addLatexItem,
+	getIdToAdd,
+	setBookmark,
+} from "./sliceUtil";
+
+export default {
+	setSelectedButton(state, { payload }) {
+		state.selectedButton = payload;
+	},
+	setLatexInput(state, { payload }) {
+		if (state.pastLatexInput === payload) return;
+		state.futureLatexCommands = [];
+		state.pastLatexCommands.unshift(state.latexInput);
+		state.pastLatexInput = state.latexInput;
+		state.latexInput = payload;
+	},
+	setLatexTextInput(state, { payload }) {
+		state.futureLatexCommands = [];
+		state.pastLatexCommands.unshift(state.latexInput);
+		state.pastLatexInput = payload;
+		state.latexInput = payload;
+	},
+	setFont(state, { payload }) {
+		state.fontInfo = { size: payload.size, color: payload.color };
+	},
+	setAlign(state, { payload }) {
+		state.alignInfo = payload;
+	},
+	undoEvent(state) {
+		if (state.pastLatexCommands.length === 0) return;
+		state.futureLatexCommands.unshift(state.latexInput);
+		state.pastLatexInput = state.pastLatexCommands[0];
+		state.latexInput = state.pastLatexCommands.shift();
+	},
+	redoEvent(state) {
+		if (state.futureLatexCommands.length === 0) return;
+		state.pastLatexCommands.unshift(state.latexInput);
+		state.pastLatexInput = state.futureLatexCommands[0];
+		state.latexInput = state.futureLatexCommands.shift();
+	},
+	resetEvent(state) {
+		state.pastLatexCommands.unshift(state.latexInput);
+		state.latexInput = "";
+	},
+	addBookmarkItem(state, { payload }) {
+		addLatexItem(state, { latex: payload, isBookmark: true });
+		updateSidebar(state);
+	},
+	setBookmarkItem(state, { payload }) {
+		setBookmark(state, payload);
+		updateSidebar(state);
+	},
+	addRecentItem(state, { payload }) {
+		addLatexItem(state, { latex: payload, isRecent: true });
+
+		if (state.tempSavedLatexId !== INITIAL_ID) {
+			state.latexList = state.latexList.filter(({ id }) => id !== state.tempSavedLatexId);
+			state.tempSavedLatexId = INITIAL_ID;
+		}
+
+		clearTimeout(state.timerId);
+		updateSidebar(state);
+	},
+	deleteRecentItem(state, { payload }) {
+		const latexItem = state.latexList.find(({ id }) => id === payload);
+
+		latexItem.isRecent = false;
+		updateSidebar(state);
+	},
+	setBubblePopupOn(state, { payload }) {
+		const { target, isOpen, message } = payload;
+
+		state.bubblePopup[target] = { isOpen, message };
+	},
+	setCustomCommandList(state, { payload }) {
+		state.customCommandList = payload;
+		updateCustomCommandList(state);
+	},
+	setCustomFormValue(state, { payload }) {
+		state.customFormValue = payload;
+	},
+	setTimerId(state, { payload }) {
+		state.timerId = payload;
+	},
+	setCustomFormLatex(state, { payload }) {
+		state.customFormValue.latex = payload;
+	},
+	setTempSavedItem(state, { payload }) {
+		if (state.tempSavedLatexId === INITIAL_ID) {
+			const id = getIdToAdd(state.latexList);
+			const newItem = { id, latex: state.latexInput, isRecent: true, isBookmark: false };
+
+			state.latexList.push(newItem);
+			state.tempSavedLatexId = id;
+			updateSidebar(state);
+
+			return;
+		}
+
+		const targetItem = state.latexList.find(({ id }) => id === state.tempSavedLatexId);
+
+		targetItem.latex = state.latexInput;
+		updateSidebar(state);
+	},
+};

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -23,10 +23,10 @@ export default function BodyContainer() {
 
 	const handleLatexInput = customList => mathField => {
 		const mathFieldLatex = mathField.latex();
-		const target = customList.find(elem => mathFieldLatex.includes(elem.command));
+		const target = customList.find(elem => mathFieldLatex.includes(`#${elem.command}\\`));
 
 		if (target) {
-			dispatch(setLatexInputWithDebounce(mathFieldLatex.replace(target.command, target.latex)));
+			dispatch(setLatexInputWithDebounce(mathFieldLatex.replace(`#${target.command}\\`, target.latex)));
 			return;
 		}
 		dispatch(setLatexInputWithDebounce(mathFieldLatex));

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -22,12 +22,11 @@ export default function BodyContainer() {
 	} = useSelector(state => state);
 
 	const handleLatexInput = customList => mathField => {
-		const mathFieldLatex = mathField.latex();
+		let mathFieldLatex = mathField.latex();
 		const target = customList.find(elem => mathFieldLatex.includes(`#${elem.command}\\`));
 
 		if (target) {
-			dispatch(setLatexInputWithDebounce(mathFieldLatex.replace(`#${target.command}\\`, target.latex)));
-			return;
+			mathFieldLatex = mathFieldLatex.replace(`#${target.command}\\`, target.latex);
 		}
 		dispatch(setLatexInputWithDebounce(mathFieldLatex));
 	};

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { deleteRecentItem, setBookmarkItem, setLatexInput, setCustomFormValue } from "../slice";
-import { BOOKMARK_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
+import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
@@ -14,7 +14,6 @@ export default function RecentContainer({ onScroll, setTabState, setSidebar }) {
 
 	const handleBookmarkButtonClick = (id, isBookmark) => () => {
 		dispatch(setBookmarkItem({ id, isBookmark: !isBookmark }));
-		if (!isBookmark) setTabState(BOOKMARK_TAB);
 	};
 
 	const handleCustomButtonClick = latex => () => {

--- a/src/slice.js
+++ b/src/slice.js
@@ -1,15 +1,11 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+import actionCreator from "./actionCreator";
 import {
 	INITIAL_ID,
 	initLatexList,
-	updateSidebar,
-	updateCustomCommandList,
-	addLatexItem,
-	getIdToAdd,
 	compareRecent,
 	compareBookmark,
-	setBookmark,
 	CUSTOM_LIST,
 	getLocalStorage,
 } from "./sliceUtil";
@@ -42,106 +38,7 @@ const { reducer, actions } = createSlice({
 		customFormValue: { state: false, name: "등록", command: "", latex: "", id: -1, isDisabled: false },
 		timerId: "",
 	},
-	reducers: {
-		setSelectedButton(state, { payload }) {
-			state.selectedButton = payload;
-		},
-		setLatexInput(state, { payload }) {
-			if (state.pastLatexInput === payload) return;
-			state.futureLatexCommands = [];
-			state.pastLatexCommands.unshift(state.latexInput);
-			state.pastLatexInput = state.latexInput;
-			state.latexInput = payload;
-		},
-		setLatexTextInput(state, { payload }) {
-			state.futureLatexCommands = [];
-			state.pastLatexCommands.unshift(state.latexInput);
-			state.pastLatexInput = payload;
-			state.latexInput = payload;
-		},
-		setFont(state, { payload }) {
-			state.fontInfo = { size: payload.size, color: payload.color };
-		},
-		setAlign(state, { payload }) {
-			state.alignInfo = payload;
-		},
-		undoEvent(state) {
-			if (state.pastLatexCommands.length === 0) return;
-			state.futureLatexCommands.unshift(state.latexInput);
-			state.pastLatexInput = state.pastLatexCommands[0];
-			state.latexInput = state.pastLatexCommands.shift();
-		},
-		redoEvent(state) {
-			if (state.futureLatexCommands.length === 0) return;
-			state.pastLatexCommands.unshift(state.latexInput);
-			state.pastLatexInput = state.futureLatexCommands[0];
-			state.latexInput = state.futureLatexCommands.shift();
-		},
-		resetEvent(state) {
-			state.pastLatexCommands.unshift(state.latexInput);
-			state.latexInput = "";
-		},
-		addBookmarkItem(state, { payload }) {
-			addLatexItem(state, { latex: payload, isBookmark: true });
-			updateSidebar(state);
-		},
-		setBookmarkItem(state, { payload }) {
-			setBookmark(state, payload);
-			updateSidebar(state);
-		},
-		addRecentItem(state, { payload }) {
-			addLatexItem(state, { latex: payload, isRecent: true });
-
-			if (state.tempSavedLatexId !== INITIAL_ID) {
-				state.latexList = state.latexList.filter(({ id }) => id !== state.tempSavedLatexId);
-				state.tempSavedLatexId = INITIAL_ID;
-			}
-
-			clearTimeout(state.timerId);
-			updateSidebar(state);
-		},
-		deleteRecentItem(state, { payload }) {
-			const latexItem = state.latexList.find(({ id }) => id === payload);
-
-			latexItem.isRecent = false;
-			updateSidebar(state);
-		},
-		setBubblePopupOn(state, { payload }) {
-			const { target, isOpen, message } = payload;
-
-			state.bubblePopup[target] = { isOpen, message };
-		},
-		setCustomCommandList(state, { payload }) {
-			state.customCommandList = payload;
-			updateCustomCommandList(state);
-		},
-		setCustomFormValue(state, { payload }) {
-			state.customFormValue = payload;
-		},
-		setTimerId(state, { payload }) {
-			state.timerId = payload;
-		},
-		setCustomFormLatex(state, { payload }) {
-			state.customFormValue.latex = payload;
-		},
-		setTempSavedItem(state, { payload }) {
-			if (state.tempSavedLatexId === INITIAL_ID) {
-				const id = getIdToAdd(state.latexList);
-				const newItem = { id, latex: state.latexInput, isRecent: true, isBookmark: false };
-
-				state.latexList.push(newItem);
-				state.tempSavedLatexId = id;
-				updateSidebar(state);
-
-				return;
-			}
-
-			const targetItem = state.latexList.find(({ id }) => id === state.tempSavedLatexId);
-
-			targetItem.latex = state.latexInput;
-			updateSidebar(state);
-		},
-	},
+	reducers: actionCreator,
 });
 
 export const {


### PR DESCRIPTION
## 변경사항
- `slice.js`에서 `actionCreator` 함수 파일 분리
- 최근 수식 탭에서 북마크 등록시 북마크 탭으로 이동하지 않게 변경
- `#command`로 커스텀 명령어 실행되도록 변경
- BodyContainer 중복되는 로직 제거