### PR TITLE
하단 버튼의 버블팝업 스타일 변경

### DIFF
--- a/src/presentationals/BubblePopup.jsx
+++ b/src/presentationals/BubblePopup.jsx
@@ -3,54 +3,35 @@ import styled from "styled-components";
 
 import { color } from "../GlobalStyle";
 
+const transition = "0.5s";
+
 const Layout = styled.div`
   position: absolute;
-  transition: 0.5s;
+  transition: ${transition};
   width: max-content;
   z-index: 2;
-  transform: translate(-17%, 0);
-  
-  ${({ isOpen }) =>
-		(isOpen ? `
-      display: block;
-      top: 600px;
-    ` : `
-      display: block;
-      top: 640px;
-    `)}
+  transform: translateX(-17%);
+  display: block;
+  top: ${({ isOpen }) => (isOpen ? "-70" : "-30")}px;
 `;
 
 const Message = styled.div`
-  width: max-content;
   padding: 10px 20px;
   font-weight: bold;
   border-radius: 10px;
-  transition: 0.5s;
-
-  ${({ isOpen }) =>
-		(isOpen ? `
-      background-color: ${color.normal};
-      color: white;
-    ` : `
-      background-color: #4db6ac00;
-      color: #ffffff00;
-    `)}
+  transition: ${transition};
+  background-color: ${color.normal};
+  color: white;
+  opacity: ${({ isOpen }) => (isOpen ? "1" : "0")};
 `;
 
 const Triangle = styled.div`
   margin: 0 auto;
-  width: 0px;
-  height: 0px;
+  width: 0;
   border-right: 10px solid transparent;
   border-left: 10px solid transparent;
-  transition: 0.5s;
-
-  ${({ isOpen }) =>
-		(isOpen ? `
-      border-top: 15px solid ${color.normal};
-    ` : `
-      border-top: 15px solid #4db6ac00;
-    `)}
+  border-top: 15px solid ${({ isOpen }) => (isOpen ? color.normal : `transparent`)};
+  transition: ${transition};
 `;
 
 export default function BubblePopup({ isOpen, message }) {

--- a/src/presentationals/FooterButton.jsx
+++ b/src/presentationals/FooterButton.jsx
@@ -24,9 +24,9 @@ const FooterButtonStyle = styled.button`
 
 export default function FooterButton({ name, onClick, isOpen, message }) {
 	return (
-		<Layout onClick={onClick}>
+		<Layout>
 			<BubblePopup isOpen={isOpen} message={message} />
-			<FooterButtonStyle>{name}</FooterButtonStyle>
+			<FooterButtonStyle onClick={onClick}>{name}</FooterButtonStyle>
 		</Layout>
 	);
 }

--- a/src/presentationals/FooterButton.jsx
+++ b/src/presentationals/FooterButton.jsx
@@ -4,7 +4,9 @@ import styled from "styled-components";
 import { color } from "../GlobalStyle";
 import BubblePopup from "./BubblePopup";
 
-const Layout = styled.div``;
+const Layout = styled.div`
+	position: relative;
+`;
 
 const FooterButtonStyle = styled.button`
 	position: relative;


### PR DESCRIPTION
## 변경사항
- 팝업 메시지의 `top` 값을 절대 위치에서 상대 위치로 변경
- 하단 버튼 외부(투명한 팝업 컴포넌트)를 클릭해도 동작하는 버그 해결
- 기존 코드를 좀 더 간결하게 수정