### PR TITLE
confirm 팝업 생성 및 리팩토링

### DIFF
--- a/src/actionCreator.js
+++ b/src/actionCreator.js
@@ -4,10 +4,10 @@ import {
 	updateCustomCommandList,
 	addLatexItem,
 	getIdToAdd,
-	setBookmark,
 	RECENT_TAB,
 	BOOKMARK_TAB,
 	CUSTOM_COMMAND_TAB,
+	setLatexItem,
 } from "./sliceUtil";
 
 export default {
@@ -54,8 +54,7 @@ export default {
 		updateSidebar(state);
 	},
 	setBookmarkItem(state, { payload }) {
-		setBookmark(state, payload);
-		updateSidebar(state);
+		setLatexItem(state, payload);
 	},
 	removeAllBookmarkItems(state) {
 		state.latexList.forEach(item => {
@@ -72,12 +71,6 @@ export default {
 		}
 
 		clearTimeout(state.timerId);
-		updateSidebar(state);
-	},
-	deleteRecentItem(state, { payload }) {
-		const latexItem = state.latexList.find(({ id }) => id === payload);
-
-		latexItem.isRecent = false;
 		updateSidebar(state);
 	},
 	removeAllRecentItems(state) {
@@ -104,7 +97,7 @@ export default {
 	setCustomFormLatex(state, { payload }) {
 		state.customFormValue.latex = payload;
 	},
-	setTempSavedItem(state, { payload }) {
+	setTempSavedItem(state) {
 		if (state.tempSavedLatexId === INITIAL_ID) {
 			const id = getIdToAdd(state.latexList);
 			const newItem = { id, latex: state.latexInput, isRecent: true, isBookmark: false };
@@ -132,12 +125,10 @@ export default {
 
 		switch (dataToDelete.tabId) {
 			case RECENT_TAB:
-				state.latexList.find(({ id }) => id === dataToDelete.id).isRecent = false;
-				updateSidebar(state);
+				setLatexItem(state, { id: dataToDelete.id, isRecent: false });
 				break;
 			case BOOKMARK_TAB:
-				setBookmark(state, { id: dataToDelete.id, isBookmark: false });
-				updateSidebar(state);
+				setLatexItem(state, { id: dataToDelete.id, isBookmark: false });
 				break;
 			case CUSTOM_COMMAND_TAB:
 				state.customFormValue = { ...state.customFormValue, state: false };

--- a/src/actionCreator.js
+++ b/src/actionCreator.js
@@ -8,6 +8,7 @@ import {
 	BOOKMARK_TAB,
 	CUSTOM_COMMAND_TAB,
 	setLatexItem,
+	deleteCustomCommand,
 } from "./sliceUtil";
 
 export default {
@@ -131,9 +132,7 @@ export default {
 				setLatexItem(state, { id: dataToDelete.id, isBookmark: false });
 				break;
 			case CUSTOM_COMMAND_TAB:
-				state.customFormValue = { ...state.customFormValue, state: false };
-				state.customCommandList = state.customCommandList.filter((_, id) => id !== dataToDelete.index);
-				updateCustomCommandList(state);
+				deleteCustomCommand(state, { id: dataToDelete.index });
 				break;
 			default:
 		}

--- a/src/actionCreator.js
+++ b/src/actionCreator.js
@@ -5,6 +5,9 @@ import {
 	addLatexItem,
 	getIdToAdd,
 	setBookmark,
+	RECENT_TAB,
+	BOOKMARK_TAB,
+	CUSTOM_COMMAND_TAB,
 } from "./sliceUtil";
 
 export default {
@@ -117,5 +120,31 @@ export default {
 
 		targetItem.latex = state.latexInput;
 		updateSidebar(state);
+	},
+	openConfirmModal(state, { payload }) {
+		state.confirmModal.isOpen = true;
+		state.confirmModal.data = payload;
+	},
+	closeConfirmModal(state, { payload }) {
+		state.confirmModal.isOpen = false;
+		if (!payload) return;
+		const dataToDelete = state.confirmModal.data;
+
+		switch (dataToDelete.tabId) {
+			case RECENT_TAB:
+				state.latexList.find(({ id }) => id === dataToDelete.id).isRecent = false;
+				updateSidebar(state);
+				break;
+			case BOOKMARK_TAB:
+				setBookmark(state, { id: dataToDelete.id, isBookmark: false });
+				updateSidebar(state);
+				break;
+			case CUSTOM_COMMAND_TAB:
+				state.customFormValue = { ...state.customFormValue, state: false };
+				state.customCommandList = state.customCommandList.filter((_, id) => id !== dataToDelete.index);
+				updateCustomCommandList(state);
+				break;
+			default:
+		}
 	},
 };

--- a/src/containers/BookmarkContainer.jsx
+++ b/src/containers/BookmarkContainer.jsx
@@ -3,12 +3,12 @@ import { useDispatch, useSelector } from "react-redux";
 
 import {
 	addBookmarkItem,
-	setBookmarkItem,
 	setCustomFormValue,
 	setLatexInput,
 	removeAllBookmarkItems,
+	openConfirmModal,
 } from "../slice";
-import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
+import { BOOKMARK_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
@@ -35,9 +35,7 @@ export default function BookmarkContainer({ onScroll, setSidebar, setTabState })
 	};
 
 	const handleDeleteButton = id => () => {
-		if (confirm("정말로 삭제하시겠습니까?")) {
-			dispatch(setBookmarkItem({ id, isBookmark: false }));
-		}
+		dispatch(openConfirmModal({ tabId: BOOKMARK_TAB, id }));
 	};
 
 	const handleDeleteAllClick = () => {

--- a/src/containers/CustomContainer.jsx
+++ b/src/containers/CustomContainer.jsx
@@ -1,13 +1,19 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import {
+	setCustomCommandList,
+	setCustomFormLatex,
+	setCustomFormValue,
+	openConfirmModal,
+} from "../slice";
 import ListLayout from "../layouts/ListLayout";
 import CustomAddButton from "../presentationals/CustomAddButton";
 import CustomForm from "../presentationals/CustomForm";
 import CustomItem from "../presentationals/CustomItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
 import EmptyItem from "../presentationals/EmptyItem";
-import { deleteCustomCommand, setCustomCommandList, setCustomFormLatex, setCustomFormValue } from "../slice";
+import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 
 export default function CustomContainer({ onScroll }) {
 	const { customCommandList, customFormValue } = useSelector(state => state);
@@ -24,11 +30,7 @@ export default function CustomContainer({ onScroll }) {
 	};
 
 	const handleDeleteClick = index => () => {
-		if (confirm("정말로 삭제하시겠습니까?")) {
-			const tempCustomCommands = [...customCommandList].filter((_, id) => id !== index);
-
-			dispatch(deleteCustomCommand({ customFormValue, tempCustomCommands }));
-		}
+		dispatch(openConfirmModal({ tabId: CUSTOM_COMMAND_TAB, index }));
 	};
 
 	const handleSubmit = e => {

--- a/src/containers/RecentContainer.jsx
+++ b/src/containers/RecentContainer.jsx
@@ -2,13 +2,13 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
-	deleteRecentItem,
 	setBookmarkItem,
 	setLatexInput,
 	setCustomFormValue,
 	removeAllRecentItems,
+	openConfirmModal,
 } from "../slice";
-import { CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
+import { RECENT_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import ListLayout from "../layouts/ListLayout";
 import ListItem from "../presentationals/ListItem";
 import SideBarHeader from "../presentationals/SideBarHeader";
@@ -28,9 +28,7 @@ export default function RecentContainer({ onScroll, setTabState, setSidebar }) {
 	};
 
 	const handleDeleteButtonClick = id => () => {
-		if (confirm("정말로 삭제하시겠습니까?")) {
-			dispatch(deleteRecentItem(id));
-		}
+		dispatch(openConfirmModal({ tabId: RECENT_TAB, id }));
 	};
 
 	const handleFormulaClick = latex => () => {

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 
+import { closeConfirmModal } from "../slice";
 import { toFitSimple } from "../util";
 import { RECENT_TAB, BOOKMARK_TAB, CUSTOM_COMMAND_TAB } from "../constants/sidebarTab";
 import RecentContainer from "./RecentContainer";
@@ -10,8 +12,11 @@ import LessThanIcon from "../icons/LessThanIcon";
 import SideBarLayout from "../layouts/SideBarLayout";
 import SideBarTab from "../presentationals/SideBarTab";
 import IconButton from "../presentationals/IconButton";
+import ConfirmModal from "../presentationals/ConfirmModal";
 
 export default function SideBar({ mainWrapperRef }) {
+	const dispatch = useDispatch();
+	const confirmModal = useSelector(state => state.confirmModal);
 	const [tabState, setTabState] = useState(RECENT_TAB);
 	const [isOpenSidebar, setIsOpenSidebar] = useState(false);
 	const [isScrollTop, setIsScrollTop] = useState(true);
@@ -60,20 +65,32 @@ export default function SideBar({ mainWrapperRef }) {
 		return () => window.removeEventListener("click", outsideClickEvent);
 	}, []);
 
+	const handleConfirmClick = result => () => {
+		dispatch(closeConfirmModal(result));
+	};
+
 	return (
-		<SideBarLayout isOpenSidebar={isOpenSidebar}>
-			<IconButton
-				onClick={handleToggleSidebar}
-				icon={<LessThanIcon />}
+		<>
+			<ConfirmModal
+				isOpen={confirmModal.isOpen}
+				message={confirmModal.message}
+				onClickYes={handleConfirmClick(true)}
+				onClickNo={handleConfirmClick(false)}
 			/>
-			<IconButton
-				onClick={handleToggleSidebar}
-				icon={<GreaterThanIcon />}
-			/>
-			<div>
-				<SideBarTab currentTab={tabState} onClick={handleTabClick} isScrollTop={isScrollTop}/>
-				{tabMap[tabState]}
-			</div>
-		</SideBarLayout>
+			<SideBarLayout isOpenSidebar={isOpenSidebar}>
+				<IconButton
+					onClick={handleToggleSidebar}
+					icon={<LessThanIcon />}
+				/>
+				<IconButton
+					onClick={handleToggleSidebar}
+					icon={<GreaterThanIcon />}
+				/>
+				<div>
+					<SideBarTab currentTab={tabState} onClick={handleTabClick} isScrollTop={isScrollTop}/>
+					{tabMap[tabState]}
+				</div>
+			</SideBarLayout>
+		</>
 	);
 }

--- a/src/presentationals/ConfirmModal.jsx
+++ b/src/presentationals/ConfirmModal.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+
+import { color } from "../GlobalStyle";
+
+const Layout = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  background-color: ${color.light};
+  border: 1px solid ${color.dark};
+  transition: 0.5s;
+  z-index: 20;
+  ${({ isOpen }) => !isOpen && "transform: translateY(-100%);"}
+`;
+const Message = styled.div``;
+const Buttons = styled.div``;
+const Button = styled.button``;
+
+export default function ConfirmModal({ isOpen, message, onClickYes, onClickNo }) {
+	return (
+		<Layout isOpen={isOpen}>
+			<Message>{message}</Message>
+			<Buttons>
+				<Button onClick={onClickYes}>Yes</Button>
+				<Button onClick={onClickNo}>No</Button>
+			</Buttons>
+		</Layout>
+	);
+}

--- a/src/presentationals/Title.jsx
+++ b/src/presentationals/Title.jsx
@@ -5,7 +5,7 @@ import title from "../../public/title.png";
 
 const TitleStlye = styled.div`
 	text-align: center;
-	margin: 10px 0;
+	padding: 10px 0;
 	img {
 		height: 50px;
 		margin-left: 10px;

--- a/src/slice.js
+++ b/src/slice.js
@@ -55,7 +55,6 @@ export const {
 	setBookmarkItem,
 	removeAllBookmarkItems,
 	addRecentItem,
-	deleteRecentItem,
 	removeAllRecentItems,
 	setBubblePopupOn,
 	setCustomCommandList,
@@ -66,11 +65,6 @@ export const {
 	openConfirmModal,
 	closeConfirmModal,
 } = actions;
-
-export const deleteCustomCommand = payload => dispatch => {
-	dispatch(setCustomFormValue({ ...payload.customFormValue, state: false }));
-	dispatch(setCustomCommandList(payload.tempCustomCommands));
-};
 
 const setPopup = (dispatch, config, ms) => {
 	dispatch(setBubblePopupOn({ ...config, isOpen: true }));

--- a/src/slice.js
+++ b/src/slice.js
@@ -37,6 +37,7 @@ const { reducer, actions } = createSlice({
 		bookmarkItems: latexList.filter(item => item.isBookmark).sort(compareBookmark),
 		customFormValue: { state: false, name: "등록", command: "", latex: "", id: -1, isDisabled: false },
 		timerId: "",
+		confirmModal: { isOpen: false, message: "정말로 삭제하시겠습니까?", data: {} },
 	},
 	reducers: actionCreator,
 });
@@ -62,6 +63,8 @@ export const {
 	setTimerId,
 	setCustomFormLatex,
 	setTempSavedItem,
+	openConfirmModal,
+	closeConfirmModal,
 } = actions;
 
 export const deleteCustomCommand = payload => dispatch => {

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -33,10 +33,10 @@ export const updateCustomCommandList = state => {
 const getMaxValueFromList = (list, prop) =>
 	(list.length ? Math.max(...list.map(el => el[prop])) + 1 : 0);
 
-export const getIdToAdd = list => getMaxValueFromList(list, "id");
+export const getIdToAdd = list => getMaxValueFromList(list, ID);
 
 const getBookmarkPriorityToAdd = (list, isBookmark) =>
-	(isBookmark ? getMaxValueFromList(list, "bookmarkPriority") : 0);
+	(isBookmark ? getMaxValueFromList(list, BOOKMARK_PRIORITY) : 0);
 
 export const addLatexItem = (state, { latex, isRecent = false, isBookmark = false }) => {
 	const id = getIdToAdd(state.latexList);

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -46,9 +46,13 @@ export const addLatexItem = (state, { latex, isRecent = false, isBookmark = fals
 	state.latexList.push(newItem);
 };
 
-export const setBookmark = (state, { id, isBookmark }) => {
+export const setLatexItem = (state, { id, isRecent, isBookmark }) => {
 	const latexItem = state.latexList.find(item => item.id === id);
 
-	latexItem.isBookmark = isBookmark;
-	latexItem.bookmarkPriority = getBookmarkPriorityToAdd(state.bookmarkItems, isBookmark);
+	if (isRecent !== undefined) latexItem.isRecent = isRecent;
+	if (isBookmark !== undefined) {
+		latexItem.isBookmark = isBookmark;
+		latexItem.bookmarkPriority = getBookmarkPriorityToAdd(state.bookmarkItems, latexItem.isBookmark);
+	}
+	updateSidebar(state);
 };

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -56,3 +56,9 @@ export const setLatexItem = (state, { id, isRecent, isBookmark }) => {
 	}
 	updateSidebar(state);
 };
+
+export const deleteCustomCommand = (state, { id }) => {
+	state.customFormValue = { ...state.customFormValue, state: false };
+	state.customCommandList = state.customCommandList.filter((_, index) => index !== id);
+	updateCustomCommandList(state);
+};

--- a/src/sliceUtil.js
+++ b/src/sliceUtil.js
@@ -1,6 +1,9 @@
 export const LATEX_LIST = "latexList";
 export const CUSTOM_LIST = "customList";
 export const INITIAL_ID = 0;
+export const RECENT_TAB = 0;
+export const BOOKMARK_TAB = 1;
+export const CUSTOM_COMMAND_TAB = 2;
 const ID = "id";
 const BOOKMARK_PRIORITY = "bookmarkPriority";
 


### PR DESCRIPTION
## 변경사항
- 스크롤이 항상 있는 버그
  - margin이 height에 포함 안되서 넘쳤던 것을 padding으로 바꿔 처리
- 기존 사용하던 사이드바 수정,삭제 관련 actionCreator 함수들을 리팩토링

## 추가사항
- 사이드바에서 기존에 사용하던 `window.confirm()` 대신 새로 만든 `ConfirmModal`로 변경
  - redux state로 관리