### PR TITLE
사이드바와 편집기 사이의 resize 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,9 +3,7 @@ import { BrowserRouter, Route } from "react-router-dom";
 
 import GlobalStyle from "./GlobalStyle";
 import QueryStringCatcher from "./containers/QueryStringCatcher";
-import BodyContainer from "./containers/BodyContainer";
-import SideBar from "./containers/SideBar";
-import MainLayout from "./layouts/MainLayout";
+import MainContainer from "./containers/MainContainer";
 
 export default function App() {
 	return (
@@ -13,10 +11,7 @@ export default function App() {
 			<Route exact path="/">
 				<GlobalStyle />
 				<QueryStringCatcher />
-				<MainLayout >
-					<SideBar />
-					<BodyContainer />
-				</MainLayout>
+				<MainContainer />
 			</Route>
 		</BrowserRouter>
 	);

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -13,6 +13,11 @@ const GlobalStyle = createGlobalStyle`
 
 	body {
 		overflow-x: hidden;
+		-ms-user-select: none; 
+		-moz-user-select: -moz-none; 
+		-webkit-user-select: none; 
+		-khtml-user-select: none; 
+		user-select:none;
 	}
 
 	::-webkit-scrollbar { width: 12px; } /* 스크롤 바 */

--- a/src/constants/size.js
+++ b/src/constants/size.js
@@ -1,0 +1,3 @@
+export const SIDE_MIN_WIDTH = 250;
+export const INIT_SIDE_WIDTH = 320;
+export const BODY_MIN_WIDTH = 380;

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -12,7 +12,7 @@ import LatexRepresentation from "../presentationals/LatexRepresentation";
 
 import { latexFunction } from "../util";
 
-export default function BodyContainer() {
+export default function BodyContainer({ bodyWidth }) {
 	const dispatch = useDispatch();
 	const {
 		latexInput,
@@ -44,7 +44,7 @@ export default function BodyContainer() {
 	};
 
 	return (
-		<BodyLayout>
+		<BodyLayout bodyWidth={bodyWidth}>
 			<EditTabHeaderLayout>
 				<FontContainer />
 				<ControlButtonContainer />

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -11,11 +11,6 @@ import DynamicBarHorizontal from "../presentationals/DynamicBarHorizontal";
 export default function MainContainer() {
 	const sidebarMinWidth = 250;
 	const bodyMinWidth = 380;
-	const initValue = 40;
-	const [isMove, setIsMove] = useState(false);
-	const [divLeft, setDivLeft] = useState(initValue);
-	const [sidebarWidth, setSidebarWidth] = useState(initValue);
-	const bodyWidth = 100 - sidebarWidth;
 
 	const calcCurrentXRatio = pageX => {
 		let left = pageX < sidebarMinWidth ? sidebarMinWidth : pageX;
@@ -24,6 +19,13 @@ export default function MainContainer() {
 		if (right < bodyMinWidth) left = window.innerWidth - bodyMinWidth;
 		return (100 * left / window.innerWidth).toFixed(6);
 	};
+
+
+	const initValue = calcCurrentXRatio(320);
+	const [isMove, setIsMove] = useState(false);
+	const [divLeft, setDivLeft] = useState(initValue);
+	const [sidebarWidth, setSidebarWidth] = useState(initValue);
+	const bodyWidth = 100 - sidebarWidth;
 
 	const handleMouseDown = e => {
 		setIsMove(true);

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
-import { throttle } from "../util";
+import { throttle, calcCurrentXRatio } from "../util";
+import { INIT_SIDE_WIDTH } from "../constants/size";
 import BodyContainer from "./BodyContainer";
 import FooterContainer from "./FooterContainer";
 import SideBar from "./SideBar";
@@ -9,19 +10,7 @@ import MainContentWrapper from "../layouts/MainContentWrapper";
 import DynamicBarHorizontal from "../presentationals/DynamicBarHorizontal";
 
 export default function MainContainer() {
-	const sidebarMinWidth = 250;
-	const bodyMinWidth = 380;
-
-	const calcCurrentXRatio = pageX => {
-		let left = pageX < sidebarMinWidth ? sidebarMinWidth : pageX;
-		const right = (window.innerWidth - pageX);
-
-		if (right < bodyMinWidth) left = window.innerWidth - bodyMinWidth;
-		return (100 * left / window.innerWidth).toFixed(6);
-	};
-
-
-	const initValue = calcCurrentXRatio(320);
+	const initValue = calcCurrentXRatio(INIT_SIDE_WIDTH);
 	const [isMove, setIsMove] = useState(false);
 	const [divLeft, setDivLeft] = useState(initValue);
 	const [sidebarWidth, setSidebarWidth] = useState(initValue);
@@ -56,7 +45,6 @@ export default function MainContainer() {
 				isMove={isMove}
 				onMouseDown={handleMouseDown}
 				divLeft={divLeft}
-				maxWidth={sidebarMinWidth + bodyMinWidth}
 			/>
 			<MainContentWrapper bodyWidth={bodyWidth}>
 				<FooterContainer />

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+
+import { throttle } from "../util";
+import BodyContainer from "./BodyContainer";
+import SideBar from "./SideBar";
+import MainLayout from "../layouts/MainLayout";
+import DynamicBarHorizontal from "../presentationals/DynamicBarHorizontal";
+
+export default function MainContainer() {
+	const sidebarMinWidth = 250;
+	const bodyMinWidth = 360;
+	const initValue = 40;
+	const [isMove, setIsMove] = useState(false);
+	const [divLeft, setDivLeft] = useState(initValue);
+	const [sidebarWidth, setSidebarWidth] = useState(initValue);
+	const bodyWidth = 100 - sidebarWidth;
+
+	const calcCurrentXRatio = pageX => {
+		let left = pageX < sidebarMinWidth ? sidebarMinWidth : pageX;
+		const right = (window.innerWidth - pageX);
+
+		if (right < bodyMinWidth) left = window.innerWidth - bodyMinWidth;
+		return (100 * left / window.innerWidth).toFixed(6);
+	};
+
+	const handleMouseDown = e => {
+		setIsMove(true);
+		setDivLeft(e.pageX);
+	};
+
+	const handleMouseMove = e => {
+		const left = calcCurrentXRatio(e.pageX);
+
+		setDivLeft(left);
+	};
+
+	const handleMouseUp = e => {
+		const left = calcCurrentXRatio(e.pageX);
+
+		setDivLeft(left);
+		setSidebarWidth(left);
+		setIsMove(false);
+	};
+
+	return (
+		<MainLayout
+			onMouseMove={isMove ? throttle(handleMouseMove, 100) : undefined}
+			onMouseUp={isMove ? handleMouseUp : undefined}
+		>
+			<SideBar sidebarWidth={sidebarWidth} />
+			<DynamicBarHorizontal
+				isMove={isMove}
+				onMouseDown={handleMouseDown}
+				divLeft={divLeft}
+				maxWidth={sidebarMinWidth + bodyMinWidth}
+			/>
+			<BodyContainer bodyWidth={bodyWidth} />
+		</MainLayout>
+	);
+}

--- a/src/containers/SideBar.jsx
+++ b/src/containers/SideBar.jsx
@@ -8,11 +8,12 @@ import RecentContainer from "./RecentContainer";
 import BookmarkContainer from "./BookmarkContainer";
 import CustomContainer from "./CustomContainer";
 import SideBarLayout from "../layouts/SideBarLayout";
+import SideBarContentLayout from "../layouts/SideBarContentLayout";
 import SideBarTab from "../presentationals/SideBarTab";
 import ConfirmModal from "../presentationals/ConfirmModal";
 import PromptModal from "../presentationals/PromptModal";
 
-export default function SideBar() {
+export default function SideBar({ sidebarWidth }) {
 	const dispatch = useDispatch();
 	const confirmModal = useSelector(state => state.confirmModal);
 	const promptModal = useSelector(state => state.promptModal);
@@ -59,9 +60,11 @@ export default function SideBar() {
 				onClickYes={handleConfirmClick(true)}
 				onClickNo={handleConfirmClick(false)}
 			/>
-			<SideBarTab currentTab={tabState} onClick={handleTabClick} />
-			<SideBarLayout>
-				{tabMap[tabState]}
+			<SideBarLayout width={sidebarWidth}>
+				<SideBarTab currentTab={tabState} onClick={handleTabClick} />
+				<SideBarContentLayout>
+					{tabMap[tabState]}
+				</SideBarContentLayout>
 			</SideBarLayout>
 		</>
 	);

--- a/src/layouts/BodyLayout.js
+++ b/src/layouts/BodyLayout.js
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
 const BodyLayout = styled.div`
-	margin: 10px;
-	width: 100%;
+	width: ${({ bodyWidth }) => bodyWidth}%;
+	min-width: 360px;
 `;
 
 export default BodyLayout;

--- a/src/layouts/SideBarContentLayout.js
+++ b/src/layouts/SideBarContentLayout.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+import { themeColor } from "../GlobalStyle";
+
+const SideBarContentLayout = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background-color: ${themeColor.normal};
+`;
+
+export default SideBarContentLayout;

--- a/src/layouts/SideBarLayout.js
+++ b/src/layouts/SideBarLayout.js
@@ -1,13 +1,9 @@
 import styled from "styled-components";
 
-import { themeColor } from "../GlobalStyle";
-
 const SideBarLayout = styled.div`
-	min-width: 300px;
-	height: 100%;
 	display: flex;
-	flex-direction: column;
-	background-color: ${themeColor.normal};
+	width: ${({ width }) => width}%;
+	min-width: 250px;
 `;
 
 export default SideBarLayout;

--- a/src/presentationals/CharacterListItem.jsx
+++ b/src/presentationals/CharacterListItem.jsx
@@ -9,8 +9,7 @@ const Item = styled.div`
   align-items: center;
 	cursor: pointer;
 	color: ${themeColor.white};
-  height: 27px;
-	padding: 0 10px;
+	padding: 4px 10px;
 
   &:hover {
     background-color: #2B2D2E;

--- a/src/presentationals/DynamicBarHorizontal.jsx
+++ b/src/presentationals/DynamicBarHorizontal.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+
+import { themeColor } from "../GlobalStyle";
+
+const ResizeBarHorizontal = styled.div`
+	cursor: col-resize;
+	height: 100%;
+	border-right: 2px solid ${themeColor.normal};
+
+  &:hover {
+    border-right: 2px solid ${themeColor.superLight};
+  }
+
+  @media(max-width: ${({ maxWidth }) => maxWidth}px) {
+		& {
+			display: none;
+		}
+	}
+`;
+
+const DashedBarHorizontal = styled.div`
+	${prop => prop.isMove && `
+		height: 100%;
+		position: absolute;
+		border-right: 2px dashed ${themeColor.superLight};
+		left: ${prop.left}%;
+	`}
+`;
+
+export default function DynamicBarHorizontal({
+	isMove,
+	onMouseDown,
+	divLeft,
+	maxWidth,
+}) {
+	return (
+		<>
+			<ResizeBarHorizontal onMouseDown={onMouseDown} maxWidth={maxWidth}/>
+			<DashedBarHorizontal isMove={isMove} left={divLeft}/>
+		</>
+	);
+}

--- a/src/presentationals/DynamicBarHorizontal.jsx
+++ b/src/presentationals/DynamicBarHorizontal.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { themeColor } from "../GlobalStyle";
+import { SIDE_MIN_WIDTH, BODY_MIN_WIDTH } from "../constants/size";
 
 const ResizeBarHorizontal = styled.div`
 	cursor: col-resize;
@@ -12,7 +13,7 @@ const ResizeBarHorizontal = styled.div`
 		border-color: ${themeColor.superLight};
   }
 
-  @media(max-width: ${({ maxWidth }) => maxWidth}px) {
+  @media(max-width: ${SIDE_MIN_WIDTH + BODY_MIN_WIDTH}px) {
 		& {
 			display: none;
 		}
@@ -32,11 +33,10 @@ export default function DynamicBarHorizontal({
 	isMove,
 	onMouseDown,
 	divLeft,
-	maxWidth,
 }) {
 	return (
 		<>
-			<ResizeBarHorizontal onMouseDown={onMouseDown} maxWidth={maxWidth}/>
+			<ResizeBarHorizontal onMouseDown={onMouseDown}/>
 			<DashedBarHorizontal isMove={isMove} left={divLeft}/>
 		</>
 	);

--- a/src/presentationals/DynamicBarHorizontal.jsx
+++ b/src/presentationals/DynamicBarHorizontal.jsx
@@ -6,10 +6,10 @@ import { themeColor } from "../GlobalStyle";
 const ResizeBarHorizontal = styled.div`
 	cursor: col-resize;
 	height: 100%;
-	border-right: 2px solid ${themeColor.normal};
+	border-right: 3px solid ${themeColor.normal};
 
   &:hover {
-    border-right: 2px solid ${themeColor.superLight};
+		border-color: ${themeColor.superLight};
   }
 
   @media(max-width: ${({ maxWidth }) => maxWidth}px) {

--- a/src/presentationals/DynamicBarHorizontal.jsx
+++ b/src/presentationals/DynamicBarHorizontal.jsx
@@ -7,7 +7,8 @@ import { SIDE_MIN_WIDTH, BODY_MIN_WIDTH } from "../constants/size";
 const ResizeBarHorizontal = styled.div`
 	cursor: col-resize;
 	height: 100%;
-	border-right: 3px solid ${themeColor.normal};
+	border-left: 2px solid ${themeColor.normal};
+	border-right: 2px solid ${themeColor.black};
 
   &:hover {
 		border-color: ${themeColor.superLight};

--- a/src/presentationals/FormulaRepresentation.jsx
+++ b/src/presentationals/FormulaRepresentation.jsx
@@ -20,7 +20,7 @@ const FormulaRepresentationStyle = styled.div.attrs(({ fontInfo }) => ({ style: 
 		width: 100%;
 		height: 100%;
 		margin: auto;
-		padding: ${prop => prop.height / 2}px;
+		padding: ${prop => (prop.height - prop.fontInfo.size) / 2}px 0;
 		border: none;
 		text-align: ${props => props.align};
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -15,6 +15,18 @@ export const toFitSimple = cb => {
 	};
 };
 
+export const throttle = (fn, delay) => {
+	let timer = true;
+
+	return function(...args) {
+		if (!timer) return;
+		timer = false;
+		fn.apply(this, args);
+		setTimeout(() => { timer = true; }, delay);
+	};
+};
+
+
 export const encodeLatex = latex => encodeURIComponent(latex.replace(/\\ /g, " "));
 
 export const decodeQueryString = () => {

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+import { SIDE_MIN_WIDTH, BODY_MIN_WIDTH } from "./constants/size";
+
 const changeOneLetterToTwo = number => (number > 9 ? number : number.toString().padStart(2, 0));
 
 export const latexFunction = { insertLatex: () => { } };
@@ -26,7 +28,6 @@ export const throttle = (fn, delay) => {
 	};
 };
 
-
 export const encodeLatex = latex => encodeURIComponent(latex.replace(/\\ /g, " "));
 
 export const decodeQueryString = () => {
@@ -48,4 +49,12 @@ export const getCurrentDate = () => {
 	const seconds = changeOneLetterToTwo(today.getSeconds());
 
 	return `${year}.${month}.${date} ${hour}:${minutes}:${seconds}`;
+};
+
+export const calcCurrentXRatio = pageX => {
+	let left = pageX < SIDE_MIN_WIDTH ? SIDE_MIN_WIDTH : pageX;
+	const right = (window.innerWidth - pageX);
+
+	if (right < BODY_MIN_WIDTH) left = window.innerWidth - BODY_MIN_WIDTH;
+	return (100 * left / window.innerWidth).toFixed(6);
 };


### PR DESCRIPTION
## 추가사항
- 사이드바와 편집기 구역의 resize 기능 구현
  - 사이드바와 편집기 각각 min-width 이하로 줄어들지 않게 조정
- `DynamicBarHorizontal.jsx`
  - `ResizeBar` : 사이드바와 에디터 사이에 위치하는 선
  - `DashedBar` : 드래그할 때 따라다니는 점선
- `MainContainer.jsx`
  - `Sidebar`, `DynamicBar`, `MainContentWrapper`를 감싸는 컨테이너 생성
- `util/throttle()`
  - 무수히 발생하는 이벤트의 최적화를 위해 쓰로틀링 적용
- `util/calcCurrentXRatio()`
  - x좌표를 넣으면 해당 x좌표가 전체 width의 몇 %인지 계산해주는 함수
- `constants/size.js`
  - 여러군데서 사용하는 width값 같은 사이즈를 상수로 관리

## 변경사항
- 반응형을 위한 약간의 레이아웃 조정
- resize선을 조절하다보면 주변 컴포넌트가 드래그 되는 현상이 있어서 기능에 오류가 발생할 때가 있어서 블록 지정 off
- `CharacterListItem` height 값이 고정되어 있어 사이드바 사이즈가 줄었을 때, 텍스트가 겹치는 오류가 있어 수정
- 수식 편집 부분의 width가 작아지면 패딩 때문에 폭이 좁아지는 버그
  - padding값을 조정해서 좌우 패딩은 0으로 변경
  - 상하패딩도 height 반 값으로 하니 미세하게 아래쪽으로 치우쳐서 fontsize 반을 뺀 값으로 변경

## 미리보기
![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/43347250/101727922-c2d56f00-3af8-11eb-910d-fdf92fe7220a.gif)
