### PR TITLE
Dynamic Bar 크기 조절 할 때 수직 이동만 하도록 수정

### DIFF
--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -14,11 +14,11 @@ const GlobalStyle = createGlobalStyle`
 	body {
     min-height: 313px;
 		overflow-x: hidden;
-		-ms-user-select: none; 
-		-moz-user-select: -moz-none; 
-		-webkit-user-select: none; 
-		-khtml-user-select: none; 
-		user-select:none;
+		-ms-user-select: none; /* Internet Explorer/Edge */
+		-moz-user-select: -moz-none; /* Firefox */ 
+		-webkit-user-select: none; /* Safari */ 
+		-khtml-user-select: none; /* Konqueror HTML */ 
+		user-select:none; /* supported by Chrome and Opera */
 	}
 
 	::-webkit-scrollbar { width: 12px; } /* 스크롤 바 */

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -13,11 +13,8 @@ import LatexRepresentation from "../presentationals/LatexRepresentation";
 import DynamicBar from "../presentationals/DynamicBar";
 
 import { latexFunction, toFitSimple } from "../util";
-import DropdownWrapper from "../layouts/DropdownWrapper";
 
 export default function BodyContainer() {
-	let startPageY;
-	let endPageY;
 	const SUM_OF_OTHER_COMPONENTS_HEIGHT = 113;
 	const MIN_HEIGHT = 100;
 	const initialFormula = (window.innerHeight - SUM_OF_OTHER_COMPONENTS_HEIGHT) / MIN_HEIGHT * 60;
@@ -25,6 +22,8 @@ export default function BodyContainer() {
 	const maxHeight = initialFormula + initialLatex;
 	const [heights, setHeights] = useState({ formula: initialFormula, latex: initialLatex });
 	const [rateOfFormulaHeight, setRateOfFormulaHeight] = useState(60);
+	const [pageYValue, setPageYValue] = useState(0);
+	const [isMove, setIsMove] = useState(false);
 	const dispatch = useDispatch();
 	const {
 		latexInput,
@@ -55,9 +54,16 @@ export default function BodyContainer() {
 	};
 
 	const handleMouseDown = e => {
+		setIsMove(true);
+		setPageYValue(e.pageY);
 	};
 
 	const handleMouseUp = e => {
+		if (isMove) {
+			setIsMove(false);
+
+			const sub = pageYValue - e.pageY;
+
 		let expectedFormulaHeight;
 			let expectedLatexHeight;
 
@@ -109,13 +115,15 @@ export default function BodyContainer() {
 	useEffect(() => {
 		const eventFunc = toFitSimple(resizeEvent(rateOfFormulaHeight));
 
+		if (isMove) {
+			window.addEventListener("mouseup", handleMouseUp);
+		}
 		window.addEventListener("resize", eventFunc);
 		return () => {
+			window.removeEventListener("mouseup", handleMouseUp);
 			window.removeEventListener("resize", eventFunc);
 		};
 	});
-
-	const preventDefault = e => e.preventDefault();
 
 	return (
 		<BodyLayout>

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -6,6 +6,7 @@ import { getLocalStorage } from "../sliceUtil";
 import FontContainer from "./FontContainer";
 import ControlButtonContainer from "./ControlButtonContainer";
 import BodyLayout from "../layouts/BodyLayout";
+import DropdownWrapper from "../layouts/DropdownWrapper";
 import EditTabHeaderLayout from "../layouts/EditTabHeaderLayout";
 import FormulaRepresentation from "../presentationals/FormulaRepresentation";
 import LatexRepresentation from "../presentationals/LatexRepresentation";
@@ -53,15 +54,12 @@ export default function BodyContainer() {
 		dispatch(setLatexTextInputWithDebounce(e.target.value));
 	};
 
-	const handleDragStart = e => {
-		startPageY = e.pageY;
+	const handleMouseDown = e => {
 	};
 
-	const handleDrop = e => {
-		endPageY = e.pageY;
-		const sub = startPageY - endPageY;
+	const handleMouseUp = e => {
 		let expectedFormulaHeight;
-		let	expectedLatexHeight;
+			let expectedLatexHeight;
 
 		if (heights.formula - sub < MIN_HEIGHT) {
 			expectedFormulaHeight = MIN_HEIGHT;
@@ -105,6 +103,9 @@ export default function BodyContainer() {
 		setHeights(changedHeight);
 	};
 
+	const handleMouseMove = e => {
+	};
+
 	useEffect(() => {
 		const eventFunc = toFitSimple(resizeEvent(rateOfFormulaHeight));
 
@@ -122,7 +123,7 @@ export default function BodyContainer() {
 				<FontContainer />
 				<ControlButtonContainer />
 			</EditTabHeaderLayout>
-			<DropdownWrapper onDrop={handleDrop} onDragOver={preventDefault}>
+			<DropdownWrapper onMouseMove={handleMouseMove} >
 				<FormulaRepresentation
 					height={heights.formula}
 					latexInput={latexInput}
@@ -131,9 +132,7 @@ export default function BodyContainer() {
 					fontInfo={fontInfo}
 					alignInfo={alignInfo}
 				/>
-				{/* <div> */}
-				{/* <DynamicBar onMouseDown={handleMouseDown}/> */}
-				<DynamicBar onDrag={preventDefault} onDragStart={handleDragStart} />
+				<DynamicBar onMouseDown={handleMouseDown} top={heights.formula} />
 				<LatexRepresentation
 					height={heights.latex}
 					latexInput={latexInput}

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -13,7 +13,7 @@ import LatexRepresentation from "../presentationals/LatexRepresentation";
 import DynamicBar from "../presentationals/DynamicBar";
 import GhostBar from "../presentationals/GhostBar";
 
-import { latexFunction, toFitSimple } from "../util";
+import { latexFunction, throttle, toFitSimple } from "../util";
 
 export default function BodyContainer() {
 	const SUM_OF_OTHER_COMPONENTS_HEIGHT = 113;
@@ -139,7 +139,7 @@ export default function BodyContainer() {
 				<FontContainer />
 				<ControlButtonContainer />
 			</EditTabHeaderLayout>
-			<DropdownWrapper onMouseMove={handleMouseMove} >
+			<DropdownWrapper onMouseMove={throttle(handleMouseMove, 100)} >
 				<FormulaRepresentation
 					height={heights.formula}
 					latexInput={latexInput}

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -11,6 +11,7 @@ import EditTabHeaderLayout from "../layouts/EditTabHeaderLayout";
 import FormulaRepresentation from "../presentationals/FormulaRepresentation";
 import LatexRepresentation from "../presentationals/LatexRepresentation";
 import DynamicBar from "../presentationals/DynamicBar";
+import GhostBar from "../presentationals/GhostBar";
 
 import { latexFunction, toFitSimple } from "../util";
 
@@ -24,6 +25,7 @@ export default function BodyContainer() {
 	const [rateOfFormulaHeight, setRateOfFormulaHeight] = useState(60);
 	const [pageYValue, setPageYValue] = useState(0);
 	const [isMove, setIsMove] = useState(false);
+	const [ghostHeight, setGhostHeight] = useState(heights.formula);
 	const dispatch = useDispatch();
 	const {
 		latexInput,
@@ -56,6 +58,7 @@ export default function BodyContainer() {
 	const handleMouseDown = e => {
 		setIsMove(true);
 		setPageYValue(e.pageY);
+		setGhostHeight(e.pageY - 100);
 	};
 
 	const handleMouseUp = e => {
@@ -64,28 +67,30 @@ export default function BodyContainer() {
 
 			const sub = pageYValue - e.pageY;
 
-		let expectedFormulaHeight;
+			let expectedFormulaHeight;
 			let expectedLatexHeight;
 
-		if (heights.formula - sub < MIN_HEIGHT) {
-			expectedFormulaHeight = MIN_HEIGHT;
-			expectedLatexHeight = maxHeight - MIN_HEIGHT;
-		} else if (heights.latex + sub < MIN_HEIGHT) {
-			expectedLatexHeight = MIN_HEIGHT;
-			expectedFormulaHeight = maxHeight - MIN_HEIGHT;
-		} else {
-			expectedFormulaHeight = heights.formula - sub;
-			expectedLatexHeight = heights.latex + sub;
+			if (heights.formula - sub < MIN_HEIGHT) {
+				expectedFormulaHeight = MIN_HEIGHT;
+				expectedLatexHeight = maxHeight - MIN_HEIGHT;
+			} else if (heights.latex + sub < MIN_HEIGHT) {
+				expectedLatexHeight = MIN_HEIGHT;
+				expectedFormulaHeight = maxHeight - MIN_HEIGHT;
+			} else {
+				expectedFormulaHeight = heights.formula - sub;
+				expectedLatexHeight = heights.latex + sub;
+			}
+
+			const rate = expectedFormulaHeight / (window.innerHeight - SUM_OF_OTHER_COMPONENTS_HEIGHT) * 100;
+
+			setRateOfFormulaHeight(rate);
+
+			setHeights({
+				formula: expectedFormulaHeight,
+				latex: expectedLatexHeight,
+			});
+			setGhostHeight(heights.formula);
 		}
-
-		const rate = expectedFormulaHeight / (window.innerHeight - SUM_OF_OTHER_COMPONENTS_HEIGHT) * 100;
-
-		setRateOfFormulaHeight(rate);
-
-		setHeights({
-			formula: expectedFormulaHeight,
-			latex: expectedLatexHeight,
-		});
 	};
 
 	const resizeEvent = rate => () => {
@@ -110,6 +115,9 @@ export default function BodyContainer() {
 	};
 
 	const handleMouseMove = e => {
+		if (isMove) {
+			setGhostHeight(e.pageY - 100);
+		}
 	};
 
 	useEffect(() => {
@@ -140,13 +148,13 @@ export default function BodyContainer() {
 					fontInfo={fontInfo}
 					alignInfo={alignInfo}
 				/>
+				{isMove && <GhostBar ghostHeight={ghostHeight} />}
 				<DynamicBar onMouseDown={handleMouseDown} top={heights.formula} />
 				<LatexRepresentation
 					height={heights.latex}
 					latexInput={latexInput}
 					onChange={handleLatexTextarea}
 				/>
-				{/* </div> */}
 			</DropdownWrapper>
 		</BodyLayout>
 	);

--- a/src/layouts/BodyLayout.js
+++ b/src/layouts/BodyLayout.js
@@ -3,7 +3,6 @@ import styled from "styled-components";
 const BodyLayout = styled.div`
 	width: 100%;
 	padding: 0 10px;
-	/* height: fit-content; */
 `;
 
 export default BodyLayout;

--- a/src/layouts/DropdownWrapper.js
+++ b/src/layouts/DropdownWrapper.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 
 export default styled.div`
-
+	position: relative;
+	width: 100%;
 `;

--- a/src/presentationals/CustomForm.jsx
+++ b/src/presentationals/CustomForm.jsx
@@ -15,6 +15,7 @@ const Form = styled.form`
 
 	.mq-math-mode{
 		background-color: white;
+		color: black;
 	}
 	> * {
 		text-align: center;

--- a/src/presentationals/DynamicBar.jsx
+++ b/src/presentationals/DynamicBar.jsx
@@ -6,7 +6,7 @@ import AngleDownIcon from "../icons/AngleDownIcon";
 
 import { themeColor } from "../GlobalStyle";
 
-const DynamicBarStyle = styled.div`
+const DynamicBarStyle = styled.div.attrs(({ top }) => ({ style: { top: `${top}px` } }))`
 	height: 5px;
 	width: 100%;
   background-color: white;
@@ -31,11 +31,11 @@ const DynamicBarStyle = styled.div`
 	}
 `;
 
-export default function DynamicBar({ onDrag, onDragStart }) {
+export default function DynamicBar({ onMouseDown, top }) {
 	return (
-		<DynamicBarStyle draggable='true' onDrag={onDrag} onDragStart={onDragStart}>
-			<AngleUpIcon fill={themeColor.white}/>
-			<AngleDownIcon fill={themeColor.white}/>
+		<DynamicBarStyle onMouseDown={onMouseDown} top={top}>
+			<AngleUpIcon fill={themeColor.white} />
+			<AngleDownIcon fill={themeColor.white} />
 		</DynamicBarStyle>
 	);
 }

--- a/src/presentationals/DynamicBar.jsx
+++ b/src/presentationals/DynamicBar.jsx
@@ -12,6 +12,11 @@ const DynamicBarStyle = styled.div.attrs(({ top }) => ({ style: { top: `${top}px
   background-color: white;
 	position: absolute;
 	display: grid;
+	user-select: none; /* supported by Chrome and Opera */
+   -webkit-user-select: none; /* Safari */
+   -khtml-user-select: none; /* Konqueror HTML */
+   -moz-user-select: none; /* Firefox */
+   -ms-user-select: none; /* Internet Explorer/Edge */
   cursor: ns-resize;
 	svg {
 		pointer-events: none;

--- a/src/presentationals/DynamicBar.jsx
+++ b/src/presentationals/DynamicBar.jsx
@@ -10,10 +10,11 @@ const DynamicBarStyle = styled.div.attrs(({ top }) => ({ style: { top: `${top}px
 	height: 5px;
 	width: 100%;
   background-color: white;
-	position: relative;
+	position: absolute;
 	display: grid;
   cursor: ns-resize;
 	svg {
+		pointer-events: none;
 		position: relative;
 		opacity: 0;
 		margin: 0 auto;

--- a/src/presentationals/DynamicBar.jsx
+++ b/src/presentationals/DynamicBar.jsx
@@ -12,11 +12,6 @@ const DynamicBarStyle = styled.div.attrs(({ top }) => ({ style: { top: `${top}px
   background-color: white;
 	position: absolute;
 	display: grid;
-	user-select: none; /* supported by Chrome and Opera */
-   -webkit-user-select: none; /* Safari */
-   -khtml-user-select: none; /* Konqueror HTML */
-   -moz-user-select: none; /* Firefox */
-   -ms-user-select: none; /* Internet Explorer/Edge */
   cursor: ns-resize;
 	svg {
 		pointer-events: none;

--- a/src/presentationals/DynamicBarHorizontal.jsx
+++ b/src/presentationals/DynamicBarHorizontal.jsx
@@ -26,6 +26,7 @@ const DashedBarHorizontal = styled.div`
 		height: 100%;
 		position: absolute;
 		border-right: 2px dashed ${themeColor.superLight};
+		z-index: 10;
 		left: ${prop.left}%;
 	`}
 `;
@@ -37,8 +38,8 @@ export default function DynamicBarHorizontal({
 }) {
 	return (
 		<>
-			<ResizeBarHorizontal onMouseDown={onMouseDown}/>
-			<DashedBarHorizontal isMove={isMove} left={divLeft}/>
+			<ResizeBarHorizontal onMouseDown={onMouseDown} />
+			<DashedBarHorizontal isMove={isMove} left={divLeft} />
 		</>
 	);
 }

--- a/src/presentationals/GhostBar.jsx
+++ b/src/presentationals/GhostBar.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import styled from "styled-components";
+
+const Bar = styled.div.attrs(({ ghostHeight }) => ({ style: { top: `${ghostHeight}px` } }))`
+	position: absolute;	
+	width: 100%;
+  display: block; 
+	border: 1px dotted white;
+`;
+
+export default function GhostBar({ ghostHeight }) {
+	return <Bar ghostHeight={ghostHeight} />;
+}


### PR DESCRIPTION
### 추가사항
- Drag&Drop 대신 마우스 이벤트 사용
- GhostBar: 크기 조절할 때만 나타나는 미리보기용 점선

### 변경사항
- dashedBar z-index 수정해서 bodyconatiner에 묻히지 않게 수정

### 미리보기
![다이나믹바](https://user-images.githubusercontent.com/46068738/101736730-35e5e200-3b07-11eb-9aa3-57ae7b53bde7.gif)
