### PR TITLE
루트모양 깨지던 버그 및 여러 버그 수정

### DIFF
--- a/src/actionCreator.js
+++ b/src/actionCreator.js
@@ -93,6 +93,7 @@ export default {
 	},
 	removeCustomCommand(state, { payload }) {
 		state.customCommandList = state.customCommandList.filter((_, index) => index !== payload);
+		updateCustomCommandList(state);
 	},
 	setCustomCommandList(state, { payload }) {
 		state.customCommandList = payload;

--- a/src/layouts/SideBarContentLayout.js
+++ b/src/layouts/SideBarContentLayout.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { themeColor } from "../GlobalStyle";
 
 const SideBarContentLayout = styled.div`
-	width: 100%;
+	width: calc(100% - 60px);
 	height: 100%;
 	display: flex;
 	flex-direction: column;

--- a/src/layouts/SideTabItemLayout.js
+++ b/src/layouts/SideTabItemLayout.js
@@ -2,19 +2,13 @@ import styled from "styled-components";
 
 const SideTabItemLayout = styled.div`
 	&:hover {
-		> div:last-child {
-			display: block;
-    	width: 250px;
-    	position: fixed;
-    	left: 270px;
-	    transform: translate(0, -30px);
-			color: black;
-			z-index: 1;
+		> div:nth-child(2) {
+			visibility: visible;
 		}
 	}
 	
-	> div:last-child {
-		display: none;
+	> div:nth-child(2) {
+		visibility: hidden;
 	}
 `;
 

--- a/src/presentationals/CharacterListItem.jsx
+++ b/src/presentationals/CharacterListItem.jsx
@@ -54,6 +54,7 @@ const Text = styled.div`
 `;
 
 const Name = styled.div`
+	margin-left: 7px;
 	${({ isMagnifier }) => !isMagnifier &&
 	"font-family: Verdana, Geneva, Tahoma, sans-serif;"}
 `;

--- a/src/presentationals/CharacterListItem.jsx
+++ b/src/presentationals/CharacterListItem.jsx
@@ -15,9 +15,7 @@ const Item = styled.div`
     background-color: #2B2D2E;
 
 		> div > div:first-child {
-			display: flex;
-			justify-content: center;
-			align-items: center;
+			visibility: visible;
 		}
   }
 
@@ -39,9 +37,12 @@ const Magnifier = styled.div`
 	transform: translate(-50%, -15px);
 	width: 50px;
 	height: 50px;
-	display: none;
 	z-index: 5;
 	border-radius: 5px;
+	visibility: hidden;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 
 	.mq-math-mode, > div {
 		font-size: 2rem;

--- a/src/presentationals/CustomItem.jsx
+++ b/src/presentationals/CustomItem.jsx
@@ -10,7 +10,12 @@ import DeleteIcon from "../icons/DeleteIcon";
 addStyles();
 
 const Layout = styled.div`
-	position: relative;
+	position: fixed;
+	width: 250px;
+	left: 270px;
+	transform: translate(0, -30px);
+	color: black;
+	z-index: 1;
 
 	&:hover {
 		> div:last-child {
@@ -24,8 +29,8 @@ const Item = styled.div`
 	color: ${themeColor.white};
 	background-color: ${themeColor.normal};
 	border: 1px solid ${themeColor.white};
-  border-radius: 5px;
-	height: 50px;
+  border-radius: 7px;
+	height: 150px;
 	cursor: pointer;
 `;
 

--- a/src/presentationals/ListItem.jsx
+++ b/src/presentationals/ListItem.jsx
@@ -10,9 +10,12 @@ import CloseIcon from "../icons/CloseIcon";
 import IconButton from "./IconButton";
 
 const Layout = styled.div`
-	height: 150px;
-	position: relative;
-  z-index: 500;
+	position: fixed;
+	width: 250px;
+	left: 270px;
+	transform: translate(0, -30px);
+	color: black;
+	z-index: 1;
 
 	&:hover {
 		> div:first-child {
@@ -30,7 +33,7 @@ const Bottom = styled.div`
 const Item = styled.div`
 	background-color: ${themeColor.normal};
 	color: ${themeColor.white};
-	height: 100%;
+	height: 150px;
 	margin: 5px;
 	border-radius: 7px;
 	border: 1px solid ${themeColor.white};


### PR DESCRIPTION
## 변경사항
- character 탭 돋보기시 이름 가리는 버그 수정
- 루트모양 깨지는 버그 수정
  - character 탭에서 돋보기
  - 최근/북마크/커스텀에서 호버시 뜨는 아이템
- 커스텀 아이템 height 조정
- 커스텀 아이템 삭제시 로컬스토리지에 바로 업데이트 안되는 버그 수정
- 커스텀 폼 입력 내용이 커지면 레이아웃이 깨지는 버그 수정

## 미리보기
|before|after|
|:-:|:-:|
![image](https://user-images.githubusercontent.com/43347250/102052627-ae131700-3e29-11eb-8d43-02b7fb604614.png)|![image](https://user-images.githubusercontent.com/43347250/102052583-9d62a100-3e29-11eb-8ba0-8c6782fb5627.png)
![image](https://user-images.githubusercontent.com/43347250/102052682-cb47e580-3e29-11eb-9ed7-69619377cee1.png)|![image](https://user-images.githubusercontent.com/43347250/102052696-d26ef380-3e29-11eb-98f3-0cc07e674f24.png)
![image](https://user-images.githubusercontent.com/43347250/102052737-e0247900-3e29-11eb-998f-5a50ca2e803e.png)|![image](https://user-images.githubusercontent.com/43347250/102052754-e87cb400-3e29-11eb-9f00-c95a4397dfd8.png)
![image](https://user-images.githubusercontent.com/43347250/102068273-9a72ab00-3e3f-11eb-93fe-b431e05168c3.png)|![image](https://user-images.githubusercontent.com/43347250/102068300-a2324f80-3e3f-11eb-94d0-e5d160294699.png)


