### PR TITLE
자동완성 기능을 사용할 때 발생하는 버그 수정

### DIFF
--- a/src/containers/AutoKeywordContainer.jsx
+++ b/src/containers/AutoKeywordContainer.jsx
@@ -30,6 +30,11 @@ export default function AutoKeywordContainer() {
 
 	const keyupEvent = ({ keyCode }) => {
 		if (keyCode === KEY_CODE.BACK_SLASH) {
+			const cursor = latexFunction.getCursor();
+
+			if (cursor.parent.jQ[0].className.includes("text-mode")) {
+				return;
+			}
 			const backslashCountInLatex = getBackslashCountFromLatex(latexInput);
 
 			setBackslashCount(backslashCountInLatex);

--- a/src/containers/AutoKeywordContainer.jsx
+++ b/src/containers/AutoKeywordContainer.jsx
@@ -116,17 +116,16 @@ export default function AutoKeywordContainer() {
 		}
 
 		if (keyCode === KEY_CODE.ENTER || keyCode === KEY_CODE.SPACE || keyCode === KEY_CODE.TAB) {
-			const target = recommandationList[itemIndex];
-
-			const temp = buffer.current.join("").trim();
-
-			const remainedLatexPart = target.replace(`\\${temp}`, "");
-
 			while (secondBuffer.current.pop()) {
 				latexFunction.keystroke("Shift-Right Del");
 			}
 
-			latexFunction.insertLatex(remainedLatexPart);
+			const target = recommandationList[itemIndex];
+			const temp = buffer.current.join("").trim();
+
+			const remainedLatexPart = target?.replace(`\\${temp}`, "");
+
+			latexFunction.insertLatex(remainedLatexPart || "");
 
 			setRecommandationList([]);
 			buffer.current = [];

--- a/src/containers/AutoKeywordContainer.jsx
+++ b/src/containers/AutoKeywordContainer.jsx
@@ -80,7 +80,7 @@ export default function AutoKeywordContainer() {
 		if (!isOpen) return;
 
 		if (isRemoveKey(keyCode)) {
-			if (latexInput === "\\ ") {
+			if (latexInput === "\\ " && buffer.current.length === 0) {
 				toggleIsOpen(false);
 				setRecommandationList([]);
 				setBackslashCount(0);

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -54,6 +54,8 @@ export default function BodyContainer({ bodyWidth }) {
 	};
 
 	const setUpLatexInsertFunction = mathField => {
+		latexFunction.getCursor = () => mathField.__controller.cursor;
+
 		latexFunction.keystroke = key => {
 			mathField.keystroke(key);
 		};

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,7 @@ export const latexFunction = {
 	insertLatex: () => { },
 	insertClickedLatex: () => { },
 	keystroke: () => { },
+	getCursor: () => { },
 };
 
 export const toFitSimple = cb => {


### PR DESCRIPTION
## 변경 사항
- 텍스트로 인식된 부분에서 자동완성 기능을 사용하면 MathQuill 코드가 노출되고, LEFT(←)와 RIGHT(→)가 동작하지 않는 버그가 있음
  - 텍스트로 인식된 부분에서 자동완성 기능을 사용할 수 없게 하여 버그를 고침
- Backslash 입력후 자동완성 레이아웃이 나타날 수 있는 상황에서 Backspace를 여러번 입력한 이후 자동완성 기능을 사용할 수 없는 버그가 있음
  - Backspace가 입력될 때 buffer도 확인하여 buffer가 비워지지 않았다면 자동완성 기능을 계속 사용할 수 있도록 하여 버그를 고침
- 자동완성 리스트가 없을 때 자동완성 기능을 사용하면 console 창에 `target.replace()`가 함수가 아니라는 오류가 나타남
  - optional chaining을 사용하여 target 유무에 따라 입력되는 값을 다르게 하여 오류가 발생하지 않도록 함  