### PR TITLE
프레젠테이셔널 레이어 테스트 완료

### DIFF
--- a/test/presentationals/EmptyItem.test.jsx
+++ b/test/presentationals/EmptyItem.test.jsx
@@ -8,9 +8,11 @@ describe("<EmptyItem />", () => {
 	it("renders empty item", () => {
 		const test = "Test";
 		const { container } = render(<EmptyItem content={test}/>);
+		const div = container.querySelectorAll("div");
 		const svg = container.querySelector("svg");
 
 		expect(container).toHaveTextContent(test);
+		expect(div).toHaveLength(2);
 		expect(svg).toBeVisible();
 	});
 });

--- a/test/presentationals/Filter.test.jsx
+++ b/test/presentationals/Filter.test.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import Filter from "../../src/presentationals/Filter";
+
+describe("<Filter />", () => {
+	it("renders search filter", () => {
+		const onChange = () => {};
+		const { container } = render(<Filter onChange={onChange} />);
+		const input = container.querySelector("input");
+
+		expect(container).toBeDefined();
+		expect(input).toBeVisible();
+		expect(input.placeholder).toEqual("Search");
+	});
+});

--- a/test/presentationals/FormulaRepresentation.test.jsx
+++ b/test/presentationals/FormulaRepresentation.test.jsx
@@ -7,19 +7,23 @@ import FormulaRepresentation from "../../src/presentationals/FormulaRepresentati
 describe("<FormulaRepresentation />", () => {
 	it("renders formula representation", () => {
 		const latexInput = "1+2";
-		const handleLatexInput = () => {};
-		const mathquillDidMount = () => {};
+		const onEvent = () => {};
 		const fontInfo = { size: "16px", color: "black" };
 		const alignInfo = "left";
+		const height = 150;
 		const { container } = render(
 			<FormulaRepresentation
 				latexInput={latexInput}
-				handleLatexInput={handleLatexInput}
-				mathquillDidMount={mathquillDidMount}
+				onChange={onEvent}
+				mathquillDidMount={onEvent}
 				fontInfo={fontInfo}
 				alignInfo={alignInfo}
+				height={height}
 			/>);
 
-		expect(container).toHaveTextContent("1+2");
+		const EditableMathField = container.querySelector(".mq-math-mode");
+
+		expect(container).toHaveTextContent(latexInput);
+		expect(EditableMathField).toBeVisible();
 	});
 });

--- a/test/presentationals/GhostBar.test.jsx
+++ b/test/presentationals/GhostBar.test.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import GhostBar from "../../src/presentationals/GhostBar";
+
+describe("<GhostBar />", () => {
+	it("renders ghost bar", () => {
+		const ghostHeight = 150;
+		const { container } = render(<GhostBar ghostHeight={ghostHeight} />);
+		const div = container.querySelector("div");
+
+		expect(div).toBeVisible();
+	});
+});

--- a/test/presentationals/IconButton.test.jsx
+++ b/test/presentationals/IconButton.test.jsx
@@ -8,7 +8,9 @@ describe("<IconButton />", () => {
 	it("renders icon button", () => {
 		const icon = "test";
 		const { container } = render(<IconButton icon={icon} />);
+		const button = container.querySelector("button");
 
-		expect(container).toHaveTextContent(icon);
+		expect(button).toBeVisible();
+		expect(button).toHaveTextContent(icon);
 	});
 });

--- a/test/presentationals/LatexRepresentation.test.jsx
+++ b/test/presentationals/LatexRepresentation.test.jsx
@@ -9,7 +9,9 @@ describe("<LatexRepresentation />", () => {
 		const latexInput = "1 + 2";
 		const onChange = () => {};
 		const { container } = render(<LatexRepresentation latexInput={latexInput} onChange={onChange} />);
+		const textarea = container.querySelector("textarea");
 
-		expect(container).toHaveTextContent(latexInput);
+		expect(textarea).toBeVisible();
+		expect(textarea).toHaveTextContent(latexInput);
 	});
 });

--- a/test/presentationals/SideBottomTab.test.jsx
+++ b/test/presentationals/SideBottomTab.test.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SideBottomTab from "../../src/presentationals/SideBottomTab";
+
+describe("<SideBottomTab />", () => {
+	const imageDownload = { isOpen: false, message: "imageDownload" };
+	const linkCopy = { isOpen: false, message: "linkCopy" };
+	const formulaSave = { isOpen: false, message: "formulaSave" };
+	const handleFunction = () => {};
+	const svgTitles = ["수식 임시저장", "링크 복사", "이미지로 다운로드"];
+
+	it("renders side bottom tab", () => {
+		const { container } = render(
+			<SideBottomTab
+				imageDownload={imageDownload}
+				linkCopy={linkCopy}
+				formulaSave={formulaSave}
+				handleSaveFormula={handleFunction}
+				handleCopyLink={handleFunction}
+				handleDownloadAsImage={handleFunction}
+			/>,
+		);
+
+		const divs = container.querySelectorAll("div");
+		const buttons = container.querySelectorAll("button");
+		const svgs = container.querySelectorAll("svg");
+		const titles = container.querySelectorAll("title");
+
+		expect(container).toHaveTextContent(imageDownload.message);
+		expect(container).toHaveTextContent(linkCopy.message);
+		expect(container).toHaveTextContent(formulaSave.message);
+		expect(divs).toHaveLength(10);
+		expect(buttons).toHaveLength(3);
+		expect(svgs).toHaveLength(6);
+		expect(titles).toHaveLength(svgTitles.length);
+		titles.forEach((title, index) => {
+			expect(title).toHaveTextContent(svgTitles[index]);
+		});
+	});
+});

--- a/test/presentationals/SideTopTab.test.jsx
+++ b/test/presentationals/SideTopTab.test.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import SideTopTab from "../../src/presentationals/SideTopTab";
+
+describe("<SideTopTab />", () => {
+	const svgTitles = ["수식 목록", "최근 수식 목록", "북마크", "커스텀 명령어"];
+	const onClick = () => {};
+
+	it("renders side top tab", () => {
+		const { container } = render(<SideTopTab onClick={onClick}/>);
+		const divs = container.querySelectorAll("div");
+		const buttons = container.querySelectorAll("button");
+		const svgs = container.querySelectorAll("svg");
+		const titles = container.querySelectorAll("title");
+
+		expect(divs).toHaveLength(5);
+		expect(buttons).toHaveLength(svgTitles.length);
+		expect(svgs).toHaveLength(svgTitles.length);
+		expect(titles).toHaveLength(svgTitles.length);
+		titles.forEach((title, index) => {
+			expect(title).toHaveTextContent(svgTitles[index]);
+		});
+	});
+});


### PR DESCRIPTION
## 구현사항
- 기존 프레젠테이셔널 컴포넌트 몇개 업데이트
  - `EmptyItem`
  - `FormulaRepresentation`
  - `IconButton`
  - `LatexRepresentation`
- 새로 생긴 프레젠테이셔널 컴포넌트 테스트 작성
  - `Filter`
  - `GhostBar`
  - `SideBottomTab`
  - `SideTopTab`