### PR TITLE
font 크기 관련 기능 보완

### DIFF
--- a/src/containers/AutoKeywordContainer.jsx
+++ b/src/containers/AutoKeywordContainer.jsx
@@ -10,6 +10,7 @@ import AutoComplete from "../presentationals/AutoComplete";
 export default function AutoKeywordContainer() {
 	const dispatch = useDispatch();
 	const cursorPosition = useSelector(state => state.cursorPosition);
+	const fontInfo = useSelector(state => state.fontInfo);
 	const latexInput = useSelector(state => state.latexInput);
 	const [isOpen, toggleIsOpen] = useState(false);
 	const [itemIndex, setItemIndex] = useState(0);
@@ -184,6 +185,7 @@ export default function AutoKeywordContainer() {
 			isOpen={isOpen}
 			x={cursorPosition.x}
 			y={cursorPosition.y}
+			fontSize={fontInfo.size}
 			recommandationList={recommandationList}
 			targetIndex={itemIndex}
 			onClick={onClick}

--- a/src/containers/BodyContainer.jsx
+++ b/src/containers/BodyContainer.jsx
@@ -43,12 +43,10 @@ export default function BodyContainer({ bodyWidth }) {
 		}
 		dispatch(setLatexInputWithDebounce(mathFieldLatex));
 
-		const root = document.querySelector(".mq-editable-field > .mq-root-block");
-		const cursor = root.querySelector(".mq-cursor");
+		const cursorPosition = latexFunction.getCursor()._jQ[0].getClientRects();
 
-		if (!cursor) return;
-
-		const [{ x, y }] = cursor.getClientRects();
+		if (!cursorPosition.length) return;
+		const [{ x, y }] = cursorPosition;
 
 		dispatch(setCursorPosition({ x, y }));
 	};

--- a/src/containers/FontContainer.jsx
+++ b/src/containers/FontContainer.jsx
@@ -21,7 +21,7 @@ export default function FontContainer() {
 	const handleFontSizeChange = e => {
 		const MAX_FONT_SIZE = 99;
 
-		const value = e.target.value ? parseInt(e.target.value, 10) : "";
+		const value = Number(e.target.value) || "";
 		const size = value < MAX_FONT_SIZE ? value : MAX_FONT_SIZE;
 
 		setFontSizeForView(size);

--- a/src/containers/FontContainer.jsx
+++ b/src/containers/FontContainer.jsx
@@ -13,19 +13,24 @@ import IconButton from "../presentationals/IconButton";
 export default function FontContainer() {
 	const fontSizeRef = useRef();
 	const fontColorRef = useRef();
+	const [fontSizeForView, setFontSizeForView] = useState(20);
 	const [fontDropdown, setFontDropdown] = useState({ size: false, color: false });
 	const fontInfo = useSelector(state => state.fontInfo);
 	const dispatch = useDispatch();
 
 	const handleFontSizeChange = e => {
 		const MAX_FONT_SIZE = 99;
-		const value = e.target.value;
+
+		const value = e.target.value ? parseInt(e.target.value, 10) : "";
 		const size = value < MAX_FONT_SIZE ? value : MAX_FONT_SIZE;
 
+		setFontSizeForView(size);
+		if (!size) return;
 		dispatch(setFont({ ...fontInfo, size }));
 	};
 
 	const handleFontSizeItemClick = size => () => {
+		setFontSizeForView(size);
 		dispatch(setFont({ ...fontInfo, size }));
 	};
 
@@ -69,6 +74,7 @@ export default function FontContainer() {
 			<FontSizeSelector
 				fontSizeRef={fontSizeRef}
 				fontSize={fontInfo.size}
+				fontSizeForView={fontSizeForView}
 				fontDropdown={fontDropdown}
 				handleFontSizeChange={handleFontSizeChange}
 				handleFontSizeItemClick={handleFontSizeItemClick}

--- a/src/presentationals/AutoComplete.jsx
+++ b/src/presentationals/AutoComplete.jsx
@@ -7,7 +7,7 @@ import { themeColor } from "../GlobalStyle";
 const AutoKeywordLayout = styled.div`
 	position: fixed;
 	left: ${({ x }) => x}px;
-	top: ${({ y }) => y + 15}px;
+	top: ${({ y, fontSize }) => y + fontSize}px;
 	width: fit-content;
 	height: fit-content;
 	background: ${themeColor.normal};
@@ -45,13 +45,14 @@ export default function AutoComplete({
 	isOpen,
 	x,
 	y,
+	fontSize,
 	recommandationList,
 	targetIndex,
 	onClick,
 	onMouseEnter,
 }) {
 	return (
-		<AutoKeywordLayout x={x} y={y} isOpen={isOpen}>
+		<AutoKeywordLayout x={x} y={y} isOpen={isOpen} fontSize={fontSize}>
 			{ isOpen && recommandationList.map((item, index) => (
 				<HightLight data-id={index} onClick={onClick} onMouseEnter={onMouseEnter}
 					key={index} isFocused={index === parseInt(targetIndex, 10)}>

--- a/src/presentationals/FontSizeSelector.jsx
+++ b/src/presentationals/FontSizeSelector.jsx
@@ -60,6 +60,7 @@ const FontItem = styled.div`
 export default function FontSizeSelector({
 	fontSizeRef,
 	fontSize,
+	fontSizeForView,
 	fontDropdown,
 	handleFontSizeChange,
 	handleFontSizeItemClick,
@@ -69,9 +70,10 @@ export default function FontSizeSelector({
 		<Layout ref={fontSizeRef}>
 			<FontSizeIcon fill={themeColor.white}/>
 			<FontSizeInput
-				value={fontSize}
+				value={fontSizeForView}
 				onChange={handleFontSizeChange}
 				onClick={handleFontSizeInputClick}
+				placeholder={fontSize}
 			/>
 			{fontDropdown.size &&
 				<FontDropdown>

--- a/test/presentationals/FontSizeSelector.test.jsx
+++ b/test/presentationals/FontSizeSelector.test.jsx
@@ -12,6 +12,7 @@ describe("<FontSizeSelector />", () => {
 			<FontSizeSelector
 				fontSizeRef={null}
 				fontSize={defaultFontSize}
+				fontSizeForView={defaultFontSize}
 				fontDropdown={{ size: true }}
 				handleFontSizeChange={() => {}}
 				handleFontSizeItemClick={() => {}}
@@ -20,7 +21,7 @@ describe("<FontSizeSelector />", () => {
 
 		const input = container.querySelector("input");
 
-		expect(input.value).toBe(defaultFontSize);
+		expect(input).toHaveValue(defaultFontSize);
 		fontSizes.forEach(size => {
 			expect(container).toHaveTextContent(size);
 		});


### PR DESCRIPTION
## 변경 사항
- 수식 입력 영역 cursor 위치를 구할 때 MathField가 제공하는 기능을 사용하도록 리팩토링
- font 크기가 변경되어도 자동완성 레이아웃 위치가 변경되지 않는 문제 수정
- font 크기를 키보드로 입력할 때 공백이 입력되지 않아, 원하는 크기를 입력할 수 없었던 문제 수정

## 동작 결과
![동작예시](https://user-images.githubusercontent.com/46911854/102468680-30ebda00-4095-11eb-8d71-2e39aa1ccdb3.gif)
