### PR TITLE
ListItem이 진입하는 각도에 따라 달라 접근성 어려운 문제 해결

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -6,7 +6,9 @@ export const usePreviewItem = initialValue => {
 	const [previewItem, setPreviewItem] = useState(initialValue);
 
 	const handleMouseEnterItem = useCallback(id => e => {
-		setPreviewItem({ id, top: calcTopPreviewItem(e.pageY) });
+		const [{ y }] = e.target.getClientRects();
+
+		setPreviewItem({ id, top: calcTopPreviewItem(y) });
 	}, []);
 
 	return [previewItem, handleMouseEnterItem];


### PR DESCRIPTION
## 변경사항
- ListItem top값을 커서 위치로 해서 위에서 진입할 때와 아래서 진입할 때가 달라서 접근성 어려운 문제 해결
  - 커서 위치가 아닌 mouseEnter된 엘리먼트의 y좌표값으로 변경

## 미리보기
![ezgif com-gif-maker (22)](https://user-images.githubusercontent.com/43347250/102566785-88d12200-4123-11eb-816e-a88abe9298fd.gif)
