### PR TITLE
라이트 모드에서 커스텀 폼 글씨 색상 변경

### DIFF
--- a/src/presentationals/CustomForm.jsx
+++ b/src/presentationals/CustomForm.jsx
@@ -16,7 +16,7 @@ const Form = styled.form`
 		border: none;
 		outline: none;
 		background-color: ${({ theme }) => color.mainTheme4[theme]};
-		color: ${({ theme }) => (theme === "dark" ? color.white : color.black)};
+		color: ${({ theme }) => color.mainTheme0[theme]};
 		text-align: center;
 		padding: 3px;
 		margin: 3px;

--- a/src/presentationals/CustomForm.jsx
+++ b/src/presentationals/CustomForm.jsx
@@ -16,7 +16,7 @@ const Form = styled.form`
 		border: none;
 		outline: none;
 		background-color: ${({ theme }) => color.mainTheme4[theme]};
-		color: white;
+		color: ${({ theme }) => (theme === "dark" ? color.white : color.black)};
 		text-align: center;
 		padding: 3px;
 		margin: 3px;


### PR DESCRIPTION
라이트 모드에서도 여전히 글자 색상이 하얀색이라 테마에 따라 달라지도록 변경함

### 작업 내용
![image](https://user-images.githubusercontent.com/46068738/102707911-6e917280-42e2-11eb-9cf4-ec810dd75473.png)
![image](https://user-images.githubusercontent.com/46068738/102707919-751fea00-42e2-11eb-961a-cb02d7b4cc62.png)
